### PR TITLE
Upgrade and pin ruamel.yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ urllib3>=1.22
 lxml>=4.1.1
 
 # Import Export and Utils implementation
-ruamel.yaml==0.14.12 # pyup: ignore
+ruamel.yaml==0.15.42 # pyup: ignore
 deepdiff>=3.3.0
 
 # Demo deployment automation

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     'lxml',  # Required for parsing NiFi Templates
     'deepdiff',  # Required for comparing configurations
     'six',  # Required for managing Python version compatibility
-    'ruamel.yaml==0.14.12',  # Required for parsing Json/Yaml consistently
+    'ruamel.yaml==0.15.42',  # Required for parsing Json/Yaml consistently
     'docker',  # Used to deploy demo assemblies
     'requests[security]',  # Used in utils functions, security extras for Py2
     'packaging'  # Comes in setuptools anyway, used to compare versions


### PR DESCRIPTION
Needed to support Python 3.7 as per https://bitbucket.org/ruamel/yaml/issues/207/0412-fails-to-install-with-python-37 . All else seems fine when running locally on 3.7.
