### PR TITLE
Improving the experimental Forceful delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ crashlytics-build.properties
 fabric.properties
 
 /{envtmpdir}/
+
+# VSCode
+.vscode/


### PR DESCRIPTION
Fixing #167 

- Check for connection to remove only in the parent PG 
- Keep track of which controllers have been removed to avoid removing them twice (creating a set would have been an alternative)
- Remove only controllers inside the process group

Tested on NiFi 1.9 with Python 3.6