### PR TITLE
Fix force pg delete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": true
+}

--- a/docs/devnotes.rst
+++ b/docs/devnotes.rst
@@ -14,6 +14,13 @@ Decision Points
 * We use Google style Docstrings to better enable Sphinx to produce nicely readable documentation
 
 
+Testing Notes
+-------------
+
+When running tests on new code, you are advised to run 'test_default' first, then 'test_regression', then finally 'test_security'.
+Because of the way errors are propagated you may have code failures which cause a teardown which then fails because of security controls, which can then obscure the original error.
+
+
 Docker Test Environment
 -----------------------
 
@@ -22,6 +29,30 @@ There is an Apache NiFi image available on Dockerhub::
     docker pull apache/nifi:latest
 
 There are a couple of configuration files for launching various Docker environment configurations in ./test_env_config for convenience.
+
+Remote Testing on Centos7
+-------------------------
+
+Deploy a 4x16 or better on EC2 running Centos 7.5 or better, ssh in as root::
+
+    yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    yum update -y
+    yum install -y centos-release-scl yum-utils device-mapper-persistent-data lvm2
+    yum install -y rh-python36 docker
+    systemctl start docker
+    scl enable rh-python36 bash
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
+Set up remote execution environment to this server from your IDE, such as PyCharm.
+Python3 will be in a path like /opt/rh/rh-python36/root/usr/bin/python
+These commands are conveniently presented in /resources/test_setup/setup_centos7.sh
+
+You will then want to open up /home/centos/tmp/<pycharmprojectname>/resources/docker/tox-full and run::
+
+    docker-compose pull
+    docker-compose up -d
 
 Testing on OSX
 --------------

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -281,6 +281,7 @@ def list_all_processors(pg_id='root'):
     assert isinstance(pg_id, six.string_types), "pg_id should be a string"
 
     if nipyapi.utils.check_version('1.7.0') <= 0:
+        # Case where NiFi > 1.7.0
         targets = nipyapi.nifi.ProcessGroupsApi().get_processors(
             id=pg_id,
             include_descendant_groups=True
@@ -1087,7 +1088,8 @@ def list_all_controllers(pg_id='root', descendants=True):
     assert isinstance(descendants, bool)
     handle = nipyapi.nifi.FlowApi()
     # Testing shows that descendant doesn't work on NiFi-1.1.2
-    if nipyapi.utils.check_version('1.1.2') < 1:
+    if nipyapi.utils.check_version('1.1.2') >= 0:
+        # Case where NiFi <= 1.1.2
         out = []
         if descendants:
             pgs = list_all_process_groups(pg_id)
@@ -1097,6 +1099,7 @@ def list_all_controllers(pg_id='root', descendants=True):
             out += handle.get_controller_services_from_group(
                 pg.id).controller_services
     else:
+        # Case where NiFi > 1.1.2
         out = handle.get_controller_services_from_group(
             pg_id,
             include_descendant_groups=descendants
@@ -1199,7 +1202,8 @@ def schedule_controller(controller, scheduled, refresh=False):
     if refresh:
         controller = nipyapi.canvas.get_controller(controller.id, 'id')
         assert isinstance(controller, nipyapi.nifi.ControllerServiceEntity)
-    if nipyapi.utils.check_version('1.1.2') < 1:
+    if nipyapi.utils.check_version('1.1.2') >= 0:
+        # Case where NiFi <= 1.1.2
         result = update_controller(
             controller=controller,
             update=nipyapi.nifi.ControllerServiceDTO(
@@ -1207,6 +1211,7 @@ def schedule_controller(controller, scheduled, refresh=False):
             )
         )
     else:
+        # Case where NiFi > 1.1.2
         result = handle.update_run_status(
             id=controller.id,
             body=nipyapi.nifi.ControllerServiceRunStatusEntity(

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -1338,14 +1338,16 @@ def get_remote_process_group(rpg_id, summary=False):
     return out
 
 
-def create_remote_process_group(target_uris, transport='RAW', pg_id='root', position=None):
+def create_remote_process_group(target_uris, transport='RAW', pg_id='root',
+                                position=None):
     """
     Creates a new Remote Process Group with given parameters
 
     Args:
         target_uris (str): Comma separated list of target URIs
         transport (str): optional, RAW or HTTP
-        pg_id (str): optional, UUID of parent Process Group for remote process group
+        pg_id (str): optional, UUID of parent Process Group for remote
+          process group
         position (tuple): optional, tuple of location ints
 
     Returns:
@@ -1388,8 +1390,9 @@ def delete_remote_process_group(rpg, refresh=True):
     assert isinstance(rpg, nipyapi.nifi.RemoteProcessGroupEntity)
     if refresh:
         rpg = get_remote_process_group(rpg.id)
+    handle = nipyapi.nifi.RemoteProcessGroupsApi()
     with nipyapi.utils.rest_exceptions():
-        return nipyapi.nifi.RemoteProcessGroupsApi().remove_remote_process_group(
+        return handle.remove_remote_process_group(
             id=rpg.id,
             version=rpg.revision.version
         )
@@ -1397,9 +1400,11 @@ def delete_remote_process_group(rpg, refresh=True):
 
 def set_remote_process_group_transmission(rpg, enable=True, refresh=True):
     """
+    Enable or Disable Transmission for an RPG
 
     Args:
-        rpg (RemoteProcessGroupEntity): The ID of the remote process group to modify
+        rpg (RemoteProcessGroupEntity): The ID of the remote process group
+          to modify
         enable (bool): True to enable, False to disable
         refresh (bool): Whether to refresh the object before action
 
@@ -1410,8 +1415,9 @@ def set_remote_process_group_transmission(rpg, enable=True, refresh=True):
     assert isinstance(enable, bool)
     if refresh:
         rpg = get_remote_process_group(rpg.id)
+    handle = nipyapi.nifi.RemoteProcessGroupsApi()
     with nipyapi.utils.rest_exceptions():
-        return nipyapi.nifi.RemoteProcessGroupsApi().update_remote_process_group_run_status(
+        return handle.update_remote_process_group_run_status(
             id=rpg.id,
             body=nipyapi.nifi.RemotePortRunStatusEntity(
                 state='TRANSMITTING' if enable else 'STOPPED',
@@ -1482,6 +1488,7 @@ def get_funnel(funnel_id):
 
 def create_funnel(pg_id, position=None):
     """
+    Creates a Funnel Object
 
     Args:
         pg_id (str): ID of the parent Process Group
@@ -1510,6 +1517,7 @@ def create_funnel(pg_id, position=None):
 
 def delete_funnel(funnel, refresh=True):
     """
+    Deletes a Funnel Object
 
     Args:
         funnel (FunnelEntity): The Funnel to delete

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -26,7 +26,7 @@ __all__ = [
     'list_all_funnels', 'list_all_remote_process_groups', 'delete_funnel',
     'get_remote_process_group', 'update_process_group', 'create_funnel',
     'create_remote_process_group', 'delete_remote_process_group',
-    'set_remote_process_group_transmission'
+    'set_remote_process_group_transmission', 'get_pg_parents_ids'
 ]
 
 log = logging.getLogger(__name__)
@@ -379,15 +379,24 @@ def delete_process_group(process_group, force=False, refresh=True):
         )
     except nipyapi.nifi.rest.ApiException as e:
         if force:
+            # Retrieve parent process group
+            parent_pg_id = nipyapi.canvas.get_process_group(pg_id, 'id').component.parent_group_id
             # Stop, drop, and roll.
             purge_process_group(target, stop=True)
             # Remove inbound connections
-            for con in list_all_connections():
+            for con in list_all_connections(parent_pg_id):
                 if pg_id in [con.destination_group_id, con.source_group_id]:
                     delete_connection(con)
-            # Stop all Controller Services
-            for x in list_all_controllers(process_group.id):
-                delete_controller(x, True)
+            # Stop all Controller Services inside the PG ignoring the ones outside
+            controllers_list = list_all_controllers(pg_id)
+            removed_controllers_id = []
+            parent_pgs_id = get_pg_parents_ids(pg_id)
+            for x in controllers_list:
+                if not x.component.id in removed_controllers_id:
+                    if not x.component.parent_group_id in parent_pgs_id:
+                        delete_controller(x, True)
+                        removed_controllers_id.append(x.component.id)
+
             # Remove templates
             for template in nipyapi.templates.list_all_templates(native=False):
                 if target.id == template.template.group_id:
@@ -1540,3 +1549,23 @@ def delete_funnel(funnel, refresh=True):
             id=funnel.id,
             version=funnel.revision.version
         )
+
+
+def get_pg_parents_ids(pg_id):
+    """
+    Retrieve the ids of the parent Process Groups.
+
+    Args:
+        pg_id (str): Process group id
+
+    Returns:
+        (list) List of ids of the input PG parents
+    """
+    parent_groups = []
+    while pg_id:
+        pg_id = nipyapi.canvas.get_process_group(pg_id, 'id') \
+            .component.parent_group_id
+        parent_groups.append(pg_id)
+    # Removing the None value
+    parent_groups.pop()
+    return parent_groups

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -145,7 +145,7 @@ def create_service_user_group(identity, service='nifi',
     Args:
         identity (str): Identity string for the user group
         service (str): 'nifi' or 'registry'
-        users (list): A list of UserEntities belonging to the group
+        users (list): A list of nifi.UserEntity or registry.User belonging to the group
         strict (bool): Whether to throw an error on already exists
 
     Returns:
@@ -751,7 +751,9 @@ def bootstrap_security_policies(service, user_identity=None,
         None
 
     """
-    assert service in _valid_services
+    assert service in _valid_services, "service not in %s" % _valid_services
+    if user_identity is not None:
+        assert user_identity in [nipyapi.nifi.UserEntity, nipyapi.registry.User]
     if 'nifi' in service:
         rpg_id = nipyapi.canvas.get_root_pg_id()
         if user_identity is None and group_identity is None:

--- a/nipyapi/utils.py
+++ b/nipyapi/utils.py
@@ -476,6 +476,8 @@ def infer_object_label_from_class(obj):
         return 'FUNNEL'
     if isinstance(obj, nipyapi.nifi.PortEntity):
         return obj.port_type
+    if isinstance(obj, nipyapi.nifi.RemoteProcessGroupDTO):
+        return 'REMOTEPROCESSGROUP'
     if isinstance(obj, nipyapi.nifi.RemoteProcessGroupPortDTO):
         # get RPG summary, find id of obj in input or output list
         parent_rpg = nipyapi.canvas.get_remote_process_group(

--- a/resources/test_setup/setup_centos7.sh
+++ b/resources/test_setup/setup_centos7.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum update -y
+sudo yum install -y centos-release-scl yum-utils device-mapper-persistent-data lvm2
+sudo yum install -y rh-python36 docker
+sudo systemctl start docker
+sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+source /opt/rh/python36/enable
+pip install --upgrade pip
+pip install -r ../../requirements.txt
+pip install -r ../../requirements_dev.txts
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ test_resource_dir = 'resources'
 # Test template filenames should match the template PG name
 test_templates = {
     'basic': test_basename + 'Template_00',
+    'greedy': test_basename + 'Template_00_greedy',
     'complex': test_basename + 'Template_01'
 }
 
@@ -394,7 +395,7 @@ def fixture_templates(request, fix_pg):
              nipyapi.config.nifi_config.host)
     FixtureTemplates = namedtuple(
         'FixtureTemplates', ('pg', 'b_file', 'b_name', 'c_file',
-                             'c_name')
+                             'c_name', 'g_name', 'g_file')
     )
     f_pg = fix_pg
     f_b_file = path.join(
@@ -409,11 +410,19 @@ def fixture_templates(request, fix_pg):
             test_templates['complex'] + '.xml'
         )
     f_c_name = 'nipyapi_testTemplate_01'
+    f_g_file = path.join(
+        path.dirname(__file__),
+        test_resource_dir,
+        test_templates['greedy'] + '.xml'
+    )
+    f_g_name = 'nipyapi_testTemplate_00_greedy'
     out = FixtureTemplates(
         pg=f_pg,
         b_name=f_b_name,
         c_name=f_c_name,
+        g_name=f_g_name,
         b_file=f_b_file,
+        g_file=f_g_file,
         c_file=f_c_file
     )
     request.addfinalizer(remove_test_templates)

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -652,7 +652,7 @@ def test_client_recursion_limit(fix_pg, fix_funnel, target=450):
     print("Elapsed r1: {0}".format((end - start)))
 
 
-def test_remote_process_group_controls():
+def test_remote_process_group_controls(fix_proc):
     rpg1 = canvas.create_remote_process_group('http://localhost:8080/nifi')
     assert isinstance(rpg1, nifi.RemoteProcessGroupEntity)
     assert rpg1.revision is not None
@@ -662,6 +662,23 @@ def test_remote_process_group_controls():
     r2 = canvas.set_remote_process_group_transmission(rpg1, False)
     assert isinstance(r2, nifi.RemoteProcessGroupEntity)
     assert r2.status.transmission_status == 'NotTransmitting'
+    # Handle connecting to an RPG
+    # p1 = fix_proc.generate()
+    # ip = canvas.create_port(
+    #     pg_id=canvas.get_root_pg_id(),
+    #     port_type='INPUT_PORT',
+    #     name=conftest.test_basename + 'input_port',
+    #     state='STOPPED'
+    # )
+    # op = canvas.create_port(
+    #     pg_id=canvas.get_root_pg_id(),
+    #     port_type='OUTPUT_PORT',
+    #     name=conftest.test_basename + 'input_port',
+    #     state='STOPPED'
+    # )
+    # c1 = canvas.create_connection(p1, rpg1)
+    # c2 = canvas.create_connection(rpg1, op)
+    # TODO: Need to test connecting to remote environment, not just loopback
     r3 = canvas.delete_remote_process_group(rpg1)
     assert isinstance(r3, nifi.RemoteProcessGroupEntity)
     assert r3.revision is None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -256,3 +256,5 @@ def test_set_service_ssl_context():
 def test_bootstrap_security_policies():
     # This test suite makes extensive use of this call in fixtures
     pass
+
+# TODO: Test adding users to existing set of users and ensuring no clobber


### PR DESCRIPTION
Fixing #167,#180

    Check for connection to remove only in the parent PG
    Keep track of which controllers have been removed to avoid removing them twice (creating a set would have been an alternative)
    Remove only controllers inside the process group

Tested on NiFi 1.9 with Python 3.6