### PR TITLE
Added Parameter Contexts API to docs

### DIFF
--- a/docs/nipyapi-docs/nipyapi.nifi.apis.rst
+++ b/docs/nipyapi-docs/nipyapi.nifi.apis.rst
@@ -100,6 +100,14 @@ nipyapi.nifi.apis.output\_ports\_api module
     :undoc-members:
     :show-inheritance:
 
+nipyapi.nifi.apis.parameter\_contexts\_api module
+--------------------------------------
+
+.. automodule:: nipyapi.nifi.apis.parameter_contexts_api
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    
 nipyapi.nifi.apis.policies\_api module
 --------------------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,11 +29,12 @@ include =
     # Include the NiPyApi code
     nipyapi/*
 omit =
-    # Do not include procedurally generated swagger clients or demos
+    # Do not include procedurally generated swagger clients, docs or demos
     nipyapi/nifi/*
     nipyapi/registry/*
     nipyapi/demo/*
-
+    nipyapi/docs/*
+    
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Noticed the `parameter_contexts_api` is left out on readthedocs. I think this is what needs to be done to add it.

PR Overview:
Add `parameter_contexts_api` to readthedocs and omitted the docs folder from coveralls.