### PR TITLE
Fix create empty group

### DIFF
--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -137,7 +137,7 @@ def create_service_user(identity, service='nifi', strict=True):
 
 
 def create_service_user_group(identity, service='nifi',
-                              users=None, strict=True):
+                              users=[], strict=True):
     """
     Attempts to create a user with the provided identity and member users in
     the given service

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -137,7 +137,7 @@ def create_service_user(identity, service='nifi', strict=True):
 
 
 def create_service_user_group(identity, service='nifi',
-                              users=[], strict=True):
+                              users=None, strict=True):
     """
     Attempts to create a user with the provided identity and member users in
     the given service
@@ -155,25 +155,29 @@ def create_service_user_group(identity, service='nifi',
     """
     assert service in _valid_services
     assert isinstance(identity, six.string_types)
+
+    users_ids = None
+
     if service == 'nifi':
-        assert all(isinstance(user, nipyapi.nifi.UserEntity) for user in users)
-    else:
-        assert all(isinstance(user, nipyapi.registry.User) for user in users)
-    if service == 'registry':
-        user_group_obj = nipyapi.registry.UserGroup(
-            identity=identity,
-            users=[{'identifier': user.identifier} for user in users]
-        )
-    else:
-        # must be nifi
+        if users:
+            assert all(isinstance(user, nipyapi.nifi.UserEntity) for user in users)
+            users_ids = [{'id': user.id} for user in users]
         user_group_obj = nipyapi.nifi.UserGroupEntity(
             revision=nipyapi.nifi.RevisionDTO(
                 version=0
             ),
             component=nipyapi.nifi.UserGroupDTO(
                 identity=identity,
-                users=[{'id': user.id} for user in users]
+                users=users_ids
             )
+        )
+    else:
+        if users:
+            assert all(isinstance(user, nipyapi.registry.User) for user in users)
+            users_ids = [{'identifier': user.identifier} for user in users]
+        user_group_obj = nipyapi.registry.UserGroup(
+            identity=identity,
+            users=users_ids
         )
     try:
         return getattr(nipyapi, service).TenantsApi().create_user_group(


### PR DESCRIPTION
Fix this [bug-issue](https://github.com/Chaffelson/nipyapi/issues/194#issue-609205649). 
Now the developer can create a users-group by specifying only the group-identity and the service name, like this:
**In Nifi:**
`nipyapi.security.create_service_user_group('groupname')`

**And In Nifi-Registry:**
`nipyapi.security.create_service_user_group('groupname', service='registry')`.


_Solution Explanation:_
My solution based on the type of the list that `create_service_user_group` passes to: `nipyapi.nifi.UserGroupEntit` or `nipyapi.registry.UserGroup`, that can be `None`. So If the given `users` argument is `None`, we can pass `None` to the constructors.