### PR TITLE
check-version should ignore snapshot

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,6 +135,10 @@ def test_check_version(regress_nifi):
     assert utils.check_version('1.2.3', '0.2.3') == 1
     # Check RC
     assert utils.check_version('1.0.0-rc1', '1.0.0') == -1
+    # Check that snapshots are disregarded
+    assert utils.check_version('1.11.0', '1.13.0-SNAPSHOT') == -1
+    assert utils.check_version('1.11.0', "1.11.0-SNAPSHOT") == 0
+    assert utils.check_version('1.11.0', "1.10.0-SNAPSHOT") == 1
     # Check current version
     assert utils.check_version(
         system.get_nifi_version_info().ni_fi_version


### PR DESCRIPTION
A better fix would be to re-implement the version class ( which was written for python or other things ) so that it better supports the version format that nifi would support, and then offer options in the check_version function... or between the version classes or whatever such that you could say how you feel about snapshot vs release vs rc etc.

This current fix however will get you by :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chaffelson/nipyapi/232)
<!-- Reviewable:end -->
