### PR TITLE
Add support for Parameters, plus minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ language: python
 matrix:
   include:
     - python: 2.7
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
+    - python: 3.8
+    - python: 3.9
       dist: xenial
       sudo: true
 script: tox

--- a/docs/devnotes.rst
+++ b/docs/devnotes.rst
@@ -154,6 +154,8 @@ This assumes you have virtualenvwrapper, git, and appropriate python versions in
     pip install path/to/nipyapi-0.3.1-py2.py3-none-any.whl  # for example
     # Run appropriate tests, such as usage tests etc.
     deactivate
+    Push changes to Github
+    Check build on TravisCI
     # You may have to reactivate your original virtualenv
     twine upload dist/*
     # You may get a file exists error, check you're not trying to reupload an existing version

--- a/docs/devnotes.rst
+++ b/docs/devnotes.rst
@@ -156,6 +156,7 @@ This assumes you have virtualenvwrapper, git, and appropriate python versions in
     deactivate
     Push changes to Github
     Check build on TravisCI
+    Check dockerhub automated build
     # You may have to reactivate your original virtualenv
     twine upload dist/*
     # You may get a file exists error, check you're not trying to reupload an existing version

--- a/nipyapi/__init__.py
+++ b/nipyapi/__init__.py
@@ -11,7 +11,7 @@ __author__ = """Daniel Chaffelson"""
 __email__ = 'chaffelson@gmail.com'
 __version__ = '0.15.0'
 __all__ = ['canvas', 'system', 'templates', 'config', 'nifi', 'registry',
-           'versioning', 'demo', 'utils', 'security']
+           'versioning', 'demo', 'utils', 'security', 'parameters']
 
 for sub_module in __all__:
     importlib.import_module('nipyapi.' + sub_module)

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -751,7 +751,7 @@ def update_process_group(pg, update, refresh=True):
         )
 
 
-def update_processor(processor, update):
+def update_processor(processor, update, refresh=True):
     """
     Updates configuration parameters for a given Processor.
 
@@ -761,6 +761,8 @@ def update_processor(processor, update):
     Args:
         processor (ProcessorEntity): The Processor to target for update
         update (ProcessorConfigDTO): The new configuration parameters
+        refresh (bool): Whether to refresh the Processor object state
+          before applying the update
 
     Returns:
         (ProcessorEntity): The updated ProcessorEntity
@@ -771,6 +773,8 @@ def update_processor(processor, update):
             "update param is not an instance of nifi.ProcessorConfigDTO"
         )
     with nipyapi.utils.rest_exceptions():
+        if refresh:
+            processor = get_processor(processor.id, 'id')
         return nipyapi.nifi.ProcessorsApi().update_processor(
             id=processor.id,
             body=nipyapi.nifi.ProcessorEntity(

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -7,7 +7,9 @@ For interactions with the NiFi Canvas.
 from __future__ import absolute_import
 import logging
 import six
+from future.utils import raise_from as _raise
 import nipyapi
+from nipyapi.utils import exception_handler
 
 __all__ = [
     "get_root_pg_id", "recurse_flow", "get_flow", "get_process_group_status",
@@ -119,6 +121,7 @@ def get_process_group_status(pg_id='root', detail='names'):
     return raw
 
 
+@exception_handler(404, None)
 def get_process_group(identifier, identifier_type='name', greedy=True):
     """
     Filters the list of all process groups against a given identifier string
@@ -412,7 +415,7 @@ def delete_process_group(process_group, force=False, refresh=True):
                 version=target.revision.version,
                 client_id=target.revision.client_id
             )
-        raise ValueError(e.body)
+        _raise(ValueError(e.body), e)
 
 
 def create_process_group(parent_pg, new_pg_name, location, comment=''):
@@ -465,13 +468,14 @@ def list_all_processor_types():
         return nipyapi.nifi.FlowApi().get_processor_types()
 
 
-def get_processor_type(identifier, identifier_type='name'):
+def get_processor_type(identifier, identifier_type='name', greedy=True):
     """
     Gets the abstract object describing a Processor, or list thereof
 
     Args:
         identifier (str): the string to filter the list for
         identifier_type (str): the field to filter on, set in config.py
+        greedy (bool): False for exact match, True for greedy match
 
     Returns:
         None for no matches, Single Object for unique match,
@@ -481,7 +485,9 @@ def get_processor_type(identifier, identifier_type='name'):
     with nipyapi.utils.rest_exceptions():
         obj = list_all_processor_types().processor_types
     if obj:
-        return nipyapi.utils.filter_obj(obj, identifier, identifier_type)
+        return nipyapi.utils.filter_obj(
+            obj, identifier, identifier_type, greedy=greedy
+        )
     return obj
 
 
@@ -502,6 +508,8 @@ def create_processor(parent_pg, processor, location, name=None, config=None):
          (ProcessorEntity): The new Processor
 
     """
+    assert isinstance(parent_pg, nipyapi.nifi.ProcessGroupEntity)
+    assert isinstance(processor, nipyapi.nifi.DocumentedTypeDTO)
     if name is None:
         processor_name = processor.type.split('.')[-1]
     else:
@@ -528,6 +536,7 @@ def create_processor(parent_pg, processor, location, name=None, config=None):
         )
 
 
+@exception_handler(404, None)
 def get_processor(identifier, identifier_type='name', greedy=True):
     """
     Filters the list of all Processors against the given identifier string in
@@ -545,14 +554,13 @@ def get_processor(identifier, identifier_type='name', greedy=True):
     """
     assert isinstance(identifier, six.string_types)
     assert identifier_type in ['name', 'id']
-    with nipyapi.utils.rest_exceptions():
-        if identifier_type == 'id':
-            out = nipyapi.nifi.ProcessorsApi().get_processor(identifier)
-        else:
-            obj = list_all_processors()
-            out = nipyapi.utils.filter_obj(
-                obj, identifier, identifier_type, greedy=greedy
-            )
+    if identifier_type == 'id':
+        out = nipyapi.nifi.ProcessorsApi().get_processor(identifier)
+    else:
+        obj = list_all_processors()
+        out = nipyapi.utils.filter_obj(
+            obj, identifier, identifier_type, greedy=greedy
+        )
     return out
 
 
@@ -575,6 +583,8 @@ def delete_processor(processor, refresh=True, force=False):
     assert isinstance(force, bool)
     if refresh or force:
         target = get_processor(processor.id, 'id')
+        if target is None:
+            return None  # Processor does not exist
         assert isinstance(target, nipyapi.nifi.ProcessorEntity)
     else:
         target = processor
@@ -1281,7 +1291,7 @@ def get_controller(identifier, identifier_type='name', bool_response=False):
     except nipyapi.nifi.rest.ApiException as e:
         if bool_response:
             return False
-        raise ValueError(e.body)
+        _raise(ValueError(e.body), e)
     return out
 
 
@@ -1294,6 +1304,29 @@ def list_all_controller_types():
     """
     handle = nipyapi.nifi.FlowApi()
     return handle.get_controller_service_types().controller_service_types
+
+
+def get_controller_type(identifier, identifier_type='name', greedy=True):
+    """
+    Gets the abstract object describing a controller, or list thereof
+
+    Args:
+        identifier (str): the string to filter the list for
+        identifier_type (str): the field to filter on, set in config.py
+        greedy (bool): False for exact match, True for greedy match
+
+    Returns:
+        None for no matches, Single Object for unique match,
+        list(Objects) for multiple matches
+
+    """
+    with nipyapi.utils.rest_exceptions():
+        obj = list_all_controller_types()
+    if obj:
+        return nipyapi.utils.filter_obj(
+            obj, identifier, identifier_type, greedy=greedy
+        )
+    return obj
 
 
 def list_all_by_kind(kind, pg_id='root', descendants=True):

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -719,13 +719,16 @@ def schedule_processor(processor, scheduled, refresh=True):
         return False
 
 
-def update_process_group(pg, update):
+def update_process_group(pg, update, refresh=True):
     """
         Updates a given Process Group.
 
         Args:
-            pg (ProcessGroupEntity): The Processor to target for update
+            pg (ProcessGroupEntity): The Process Group to
+              target for update
             update (dict): key:value pairs to update
+            refresh (bool): Whether to refresh the Process Group before
+              applying the update
 
         Returns:
             (ProcessGroupEntity): The updated ProcessorEntity
@@ -733,6 +736,8 @@ def update_process_group(pg, update):
         """
     assert isinstance(pg, nipyapi.nifi.ProcessGroupEntity)
     with nipyapi.utils.rest_exceptions():
+        if refresh:
+            pg = get_process_group(pg.id, 'id')
         return nipyapi.nifi.ProcessGroupsApi().update_process_group(
             id=pg.id,
             body=nipyapi.nifi.ProcessGroupEntity(
@@ -1282,6 +1287,7 @@ def get_controller(identifier, identifier_type='name', bool_response=False):
     assert isinstance(identifier, six.string_types)
     assert identifier_type in ['name', 'id']
     handle = nipyapi.nifi.ControllerServicesApi()
+    out = None
     try:
         if identifier_type == 'id':
             out = handle.get_controller_service(identifier)

--- a/nipyapi/config.py
+++ b/nipyapi/config.py
@@ -25,7 +25,7 @@ logging.basicConfig(level=logging.WARNING)
 # convenience function for this in nipyapi.utils.set_endpoint
 
 # Set Default Host for NiFi
-default_host = 'localhost'  # Default to localhost for release
+default_host = '34.244.104.232'  # Default to localhost for release
 #
 nifi_config.host = os.getenv(
     'NIFI_API_ENDPOINT',

--- a/nipyapi/config.py
+++ b/nipyapi/config.py
@@ -25,7 +25,7 @@ logging.basicConfig(level=logging.WARNING)
 # convenience function for this in nipyapi.utils.set_endpoint
 
 # Set Default Host for NiFi
-default_host = 'localhost'  # Default to localhost for release
+default_host = '34.244.104.232'  # Default to localhost for release
 #
 nifi_config.host = os.getenv(
     'NIFI_API_ENDPOINT',
@@ -92,14 +92,15 @@ registered_filters = {
     'ProcessGroupEntity': {'id': ['id'], 'name': ['status', 'name']},
     'DocumentedTypeDTO': {'bundle': ['bundle', 'artifact'],
                           'name': ['type'],
-                          'tag': ['tags']},  # This is Processor Types
+                          'tag': ['tags']},
     'ProcessorEntity': {'id': ['id'], 'name': ['status', 'name']},
     'User': {'identity': ['identity'], 'id': ['identifier']},
     'UserGroupEntity': {'identity': ['component', 'identity'], 'id': ['id']},
     'UserGroup': {'identity': ['identity'], 'id': ['identifier']},
     'UserEntity': {'identity': ['component', 'identity'], 'id': ['id']},
     'TemplateEntity': {'id': ['id'], 'name': ['template', 'name']},
-    'ControllerServiceEntity': {'is': ['id'], 'name': ['component', 'name']}
+    'ControllerServiceEntity': {'id': ['id'], 'name': ['component', 'name']},
+    'ParameterContextEntity': {'id': ['id'], 'name': ['component', 'name']}
 }
 
 

--- a/nipyapi/config.py
+++ b/nipyapi/config.py
@@ -25,7 +25,7 @@ logging.basicConfig(level=logging.WARNING)
 # convenience function for this in nipyapi.utils.set_endpoint
 
 # Set Default Host for NiFi
-default_host = '34.244.104.232'  # Default to localhost for release
+default_host = 'localhost'  # Default to localhost for release
 #
 nifi_config.host = os.getenv(
     'NIFI_API_ENDPOINT',

--- a/nipyapi/parameters.py
+++ b/nipyapi/parameters.py
@@ -18,7 +18,9 @@ __all__ = [
     "list_all_parameter_contexts", "create_parameter_context",
     "delete_parameter_context", "get_parameter_context",
     "update_parameter_context", "prepare_parameter",
-    "delete_parameter_from_context"
+    "delete_parameter_from_context", "upsert_parameter_to_context",
+    "assign_context_to_process_group",
+    "remove_context_from_process_group"
 ]
 
 
@@ -217,3 +219,45 @@ def upsert_parameter_to_context(context, parameter):
     enforce_min_ver('1.10.0')
     context.component.parameters = [parameter]
     return update_parameter_context(context=context)
+
+
+def assign_context_to_process_group(pg, context_id):
+    """
+    Assigns a given Parameter Context to a specific Process Group
+
+    Args:
+        pg (ProcessGroupEntity): The Process Group to target
+        context_id (str): The ID of the Parameter Context
+
+    Returns:
+        (ProcessGroupEntity) The updated Process Group
+    """
+    assert isinstance(context_id, str)
+    return nipyapi.canvas.update_process_group(
+        pg=pg,
+        update={
+            'parameter_context': {
+                'id': context_id
+            }
+        }
+    )
+
+
+def remove_context_from_process_group(pg):
+    """
+    Clears any Parameter Context from the given Process Group
+
+    Args:
+        pg (ProcessGroupEntity): The Process Group to target
+
+    Returns:
+        (ProcessGroupEntity) The updated Process Group
+    """
+    return nipyapi.canvas.update_process_group(
+        pg=pg,
+        update={
+            'parameter_context': {
+                'id': None
+            }
+        }
+    )

--- a/nipyapi/parameters.py
+++ b/nipyapi/parameters.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+
+"""
+For Managing NiFi Parameter Contexts
+"""
+
+from __future__ import absolute_import
+import logging
+import six
+import nipyapi
+from nipyapi.utils import exception_handler, enforce_min_ver
+from nipyapi.nifi import ParameterContextEntity, ParameterDTO,\
+    ParameterEntity, ParameterContextDTO
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "list_all_parameter_contexts", "create_parameter_context",
+    "delete_parameter_context", "get_parameter_context",
+    "update_parameter_context", "prepare_parameter",
+    "delete_parameter_from_context"
+]
+
+
+def list_all_parameter_contexts():
+    """
+    Lists all Parameter Contexts available on the Canvas
+
+    Returns:
+        list(ParameterContextEntity)
+    """
+    enforce_min_ver('1.10.0')
+    handle = nipyapi.nifi.FlowApi()
+    return handle.get_parameter_contexts().parameter_contexts
+
+
+@exception_handler(404, None)
+def get_parameter_context(identifier, identifier_type='name', greedy=True):
+    """
+    Gets one or more Parameter Contexts matching a given idenitifier
+
+    Args:
+        identifier (str): The Name or ID matching Parameter Context(s)
+        identifier_type (str): 'name' or 'id'
+        greedy (bool): False for exact match, True for string match
+
+    Returns:
+        None for no matches, Single Object for unique match,
+        list(Objects) for multiple matches
+
+    """
+    enforce_min_ver('1.10.0')
+    assert isinstance(identifier, six.string_types)
+    assert identifier_type in ['name', 'id']
+    if identifier_type == 'id':
+        handle = nipyapi.nifi.ParameterContextsApi()
+        out = handle.get_parameter_context(identifier)
+    else:
+        obj = list_all_parameter_contexts()
+        out = nipyapi.utils.filter_obj(
+            obj, identifier, identifier_type, greedy=greedy
+        )
+    return out
+
+
+def create_parameter_context(name, description=None, parameters=None):
+    """
+    Create a new Parameter Context with optional description and
+        initial Parameters
+
+    Args:
+        name (str): The Name for the new Context
+        description (str): An optional description
+        parameters (list[ParameterEntity]): A list of prepared Parameters
+
+    Returns:
+        (ParameterContextEntity) The New Parameter Context
+
+    """
+    enforce_min_ver('1.10.0')
+    assert all(x is None or isinstance(x, str) for x in [name, description])
+    handle = nipyapi.nifi.ParameterContextsApi()
+    out = handle.create_parameter_context(
+        body=ParameterContextEntity(
+            revision=nipyapi.nifi.RevisionDTO(version=0),
+            component=ParameterContextDTO(
+                name=name,
+                description=description,
+                parameters=parameters if parameters else list()
+            )
+
+        )
+    )
+    return out
+
+
+def update_parameter_context(context):
+    """
+    Update an already existing Parameter Context
+
+    Args:
+        context (ParameterContextEntity): Parameter Context updated
+          to be applied
+
+    Returns:
+        (ParameterContextEntity) The updated Parameter Context
+    """
+    enforce_min_ver('1.10.0')
+
+    def _update_complete(context_id, request_id):
+        return nipyapi.nifi.ParameterContextsApi()\
+            .get_parameter_context_update(
+            context_id, request_id)\
+            .request.complete
+
+    if not isinstance(context, ParameterContextEntity):
+        raise ValueError("Supplied Parameter Context update should "
+                         "be an instance of nipyapi.nifi.ParameterContextDTO")
+    handle = nipyapi.nifi.ParameterContextsApi()
+    target = get_parameter_context(context.id, identifier_type='id')
+    update_request = handle.submit_parameter_context_update(
+        context_id=target.id,
+        body=ParameterContextEntity(
+            id=target.id,
+            revision=target.revision,
+            component=context.component
+
+        )
+    )
+    nipyapi.utils.wait_to_complete(
+        _update_complete, target.id, update_request.request.request_id,
+        nipyapi_delay=1, nipyapi_max_wait=10
+    )
+    return get_parameter_context(context.id, identifier_type='id')
+
+
+def delete_parameter_context(context):
+    """
+    Removes a Parameter Context
+
+    Args:
+        context (ParameterContextEntity): Parameter Context to be deleted
+
+    Returns:
+        (ParameterContextEntity) The removed Parameter Context
+    """
+    enforce_min_ver('1.10.0')
+    assert isinstance(context, nipyapi.nifi.ParameterContextEntity)
+    handle = nipyapi.nifi.ParameterContextsApi()
+    target = handle.get_parameter_context(context.id)
+    return handle.delete_parameter_context(
+        id=target.id,
+        version=target.revision.version
+    )
+
+
+def prepare_parameter(name, value, description=None, sensitive=False):
+    """
+    Parses basic inputs into a Parameter object ready for submission
+
+    Args:
+        name (str): The Name for the Parameter
+        value (str, int, float): The Value for the Parameter
+        description (str): Optional Description for the Parameter
+        sensitive (bool): Whether to mark the Parameter Value as sensitive
+
+    Returns:
+        (ParameterEntity) The ParameterEntity ready for use
+    """
+    enforce_min_ver('1.10.0')
+    assert all(x is None or isinstance(x, str) for x in [name, description])
+    out = ParameterEntity(
+        parameter=ParameterDTO(
+            name=name,
+            value=value,
+            description=description,
+            sensitive=sensitive
+        )
+    )
+    return out
+
+
+def delete_parameter_from_context(context, parameter_name):
+    """
+    Delete a specific Parameter from a Parameter Context
+    Args:
+        context (ParameterContextEntity): The Parameter Context to Update
+        parameter_name (str): The Parameter to delete
+
+    Returns:
+        (ParameterContextEntity) The updated Parameter Context
+    """
+    enforce_min_ver('1.10.0')
+    context.component.parameters = [
+        ParameterEntity(
+            parameter=ParameterDTO(
+                name=parameter_name
+            )
+        )
+    ]
+    return update_parameter_context(
+        context=context
+    )
+
+
+def upsert_parameter_to_context(context, parameter):
+    """
+    Insert or Update Parameter within a Parameter Context
+
+    Args:
+        context (ParameterContextEntity): The Parameter Context to Modify
+        parameter(ParameterEntity): The ParameterEntity to insert or update
+
+    Returns:
+        (ParameterContextEntity) The updated Parameter Context
+    """
+    enforce_min_ver('1.10.0')
+    context.component.parameters = [parameter]
+    return update_parameter_context(context=context)

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -390,14 +390,7 @@ def service_logout(service='nifi'):
     """
     assert service in _valid_services
     set_service_auth_token(token=None, service=service)
-    try:
-        status = get_service_access_status(service, bool_response=True)
-    except ValueError as e:
-        if 'Cannot set verify_mode to CERT_NONE' in str(e):
-            status = None
-            # Logout throws error with incorrect ssl setup
-        else:
-            raise e
+    status = get_service_access_status(service, bool_response=True)
     # Set to empty string and not None as basic auth setup will still
     # run even if not used
     getattr(nipyapi, service).configuration.password = ''

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -390,7 +390,14 @@ def service_logout(service='nifi'):
     """
     assert service in _valid_services
     set_service_auth_token(token=None, service=service)
-    status = get_service_access_status(service, bool_response=True)
+    try:
+        status = get_service_access_status(service, bool_response=True)
+    except ValueError as e:
+        if 'Cannot set verify_mode to CERT_NONE' in str(e):
+            status = None
+            # Logout throws error with incorrect ssl setup
+        else:
+            raise e
     # Set to empty string and not None as basic auth setup will still
     # run even if not used
     getattr(nipyapi, service).configuration.password = ''

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -391,7 +391,14 @@ def service_logout(service='nifi'):
     """
     assert service in _valid_services
     set_service_auth_token(token=None, service=service)
-    status = get_service_access_status(service, bool_response=True)
+    try:
+        status = get_service_access_status(service, bool_response=True)
+    except ValueError as e:
+        if 'Cannot set verify_mode to CERT_NONE' in str(e):
+            status = None
+            # Logout throws error with incorrect ssl setup
+        else:
+            raise e
     # Set to empty string and not None as basic auth setup will still
     # run even if not used
     getattr(nipyapi, service).configuration.password = ''

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -391,14 +391,7 @@ def service_logout(service='nifi'):
     """
     assert service in _valid_services
     set_service_auth_token(token=None, service=service)
-    try:
-        status = get_service_access_status(service, bool_response=True)
-    except ValueError as e:
-        if 'Cannot set verify_mode to CERT_NONE' in str(e):
-            status = None
-            # Logout throws error with incorrect ssl setup
-        else:
-            raise e
+    status = get_service_access_status(service, bool_response=True)
     # Set to empty string and not None as basic auth setup will still
     # run even if not used
     getattr(nipyapi, service).configuration.password = ''

--- a/nipyapi/templates.py
+++ b/nipyapi/templates.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-For managing flow deployments
+For Managing NiFi Templates
 """
 
 from __future__ import absolute_import

--- a/nipyapi/utils.py
+++ b/nipyapi/utils.py
@@ -596,7 +596,6 @@ def exception_handler(status_code=None, response=None):
                     nipyapi.registry.rest.ApiException) as e:
                 if status_code is not None and e.status == int(status_code):
                     return response
-                else:
-                    _raise(ValueError(e.body), e)
+                _raise(ValueError(e.body), e)
         return wrapper
     return func_wrapper

--- a/nipyapi/versioning.py
+++ b/nipyapi/versioning.py
@@ -7,6 +7,7 @@ For interactions with the NiFi Registry Service and related functions
 from __future__ import absolute_import
 import logging
 import six
+from future.utils import raise_from as _raise
 import nipyapi
 # Due to line lengths, creating shortened names for these objects
 from nipyapi.nifi import VersionControlInformationDTO as VciDTO
@@ -157,7 +158,7 @@ def delete_registry_bucket(bucket):
             bucket_id=bucket.identifier
         )
     except (nipyapi.registry.rest.ApiException, AttributeError) as e:
-        raise ValueError(e)
+        _raise(ValueError(e), e)
 
 
 def get_registry_bucket(identifier, identifier_type='name'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # Basics
 setuptools>=38.5
 six>=1.11.0
+future
 
 # Version comparison
 packaging>=17.1

--- a/resources/docker/dockerhub/Dockerfile
+++ b/resources/docker/dockerhub/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-FROM python:3.6-alpine
+FROM python:3.8-alpine
 
 LABEL maintainer="Dan Chaffelson <chaffelson@gmail.com>"
 LABEL site="https://github.com/Chaffelson/nipyapi"
@@ -32,9 +32,9 @@ RUN apk update && apk upgrade \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
     && git clone -b ${BRANCH} --depth 1 https://github.com/Chaffelson/nipyapi.git /nipyapi \
     && cd /nipyapi \
-    && pip install --no-cache --no-use-pep517 -r requirements.txt \
+    && pip install --no-cache -r requirements.txt \
     && apk del .build-deps
-    
+
 
 WORKDIR /nipyapi
 ENV PYTHONPATH=/nipyapi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 from os import environ, path
 from collections import namedtuple
+from time import sleep
 import nipyapi
 
 log = logging.getLogger(__name__)
@@ -536,6 +537,7 @@ def fixture_ver_flow(request, fix_bucket, fix_pg, fix_proc):
             comment='NiPyApi Test',
             desc='NiPyApi Test'
         )
+    sleep(0.5)
     f_flow = nipyapi.versioning.get_flow_in_bucket(
             bucket_id=f_bucket.identifier,
             identifier=f_info.version_control_information.flow_id,

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -13,10 +13,14 @@ from nipyapi.utils import check_version
 
 
 def test_create_parameter_context(regress_nifi, fix_context):
-    if check_version('1.10.0') > 0:
+    if check_version('1.10.0') >= 0:
         pytest.skip("NiFi not 1.10+")
     c1 = fix_context.generate(name=conftest.test_parameter_context_name)
     assert isinstance(c1, ParameterContextEntity)
+    with pytest.raises(AssertionError):
+        _ = parameters.create_parameter_context(name={})
+    with pytest.raises(AssertionError):
+        _ = parameters.create_parameter_context(name=conftest.test_basename, description={})
     with pytest.raises(ApiException):
         # Attempt to generate duplicate Parameter Context
         _ = fix_context.generate(name=conftest.test_parameter_context_name)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -111,3 +111,23 @@ def test_upsert_parameter_to_context(regress_nifi, fix_context):
         parameters.prepare_parameter('Black', 'Lives', 'Matter', True)
     )
     assert r1.component.parameters[0].parameter.description == 'Matter'
+
+
+def test_assign_context_to_process_group(regress_nifi, fix_pg, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate()
+    pg1 = fix_pg.generate()
+    r1 = parameters.assign_context_to_process_group(pg1, c1.id)
+    assert r1.component.parameter_context.id == c1.id
+
+
+def test_remove_context_from_process_group(regress_nifi, fix_pg, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate()
+    pg1 = fix_pg.generate()
+    r1 = parameters.assign_context_to_process_group(pg1, c1.id)
+    assert r1.component.parameter_context.id == c1.id
+    r2 = parameters.remove_context_from_process_group(pg1)
+    assert r2.component.parameter_context is None

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `nipyapi.parameters` package."""
+
+from tests import conftest
+import uuid
+import pytest
+from nipyapi import parameters
+from nipyapi.nifi import ParameterContextEntity
+from nipyapi.nifi.rest import ApiException
+from nipyapi.utils import check_version
+
+
+def test_create_parameter_context(regress_nifi, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate(name=conftest.test_parameter_context_name)
+    assert isinstance(c1, ParameterContextEntity)
+    with pytest.raises(ApiException):
+        # Attempt to generate duplicate Parameter Context
+        _ = fix_context.generate(name=conftest.test_parameter_context_name)
+
+
+def test_get_parameter_context(regress_nifi, fix_context):
+    # Because regression tests are parametrized, the skip needs to be inside the function to work properly
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    r1 = parameters.get_parameter_context('fake news', 'name')
+    assert r1 is None
+    c2 = parameters.get_parameter_context(identifier=str(uuid.uuid4()), identifier_type='id')
+    assert c2 is None
+    c1 = fix_context.generate(name=conftest.test_basename + 'instance_1')
+    r3 = parameters.get_parameter_context(c1.id, identifier_type='id')
+    assert r3.component.name == conftest.test_basename + 'instance_1'
+    c2 = fix_context.generate(name=conftest.test_basename + 'instance_2')
+    r4 = parameters.get_parameter_context(conftest.test_basename + 'instance_2', identifier_type='name')
+    assert r4.id == c2.id
+
+
+def test_list_all_parameter_contexts(regress_nifi, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    _ = fix_context.generate()
+    r1 = parameters.list_all_parameter_contexts()
+    assert isinstance(r1, list)
+    for pc in r1:
+        assert isinstance(pc, ParameterContextEntity)
+    _ = fix_context.generate(name=conftest.test_basename + 'instance_1')
+    r2 = [x for x in parameters.list_all_parameter_contexts() if conftest.test_basename in x.component.name]
+    assert isinstance(r2, list)
+    assert len(r2) == 2
+    for pc in r2:
+        assert isinstance(pc, ParameterContextEntity)
+
+
+def test_delete_parameter_context(regress_nifi, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate()
+    assert c1.revision is not None
+    r1 = parameters.delete_parameter_context(c1)
+    assert isinstance(r1, ParameterContextEntity)
+    assert r1.revision is None
+    with pytest.raises(ApiException):
+        _ = parameters.delete_parameter_context(c1)
+
+
+def test_update_parameter_context(regress_nifi, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate()
+    c1.component.parameters.append(
+        parameters.prepare_parameter('Black', 'Lives', 'Matter', True)
+    )
+    r1 = parameters.update_parameter_context(
+        c1
+    )
+    assert isinstance(r1, ParameterContextEntity)
+    assert 1 == len([x for x in r1.component.parameters if 'Black' in x.parameter.name])
+    r1.component.parameters.append(
+        parameters.prepare_parameter('Black', 'Votes', 'Matter', True)
+    )
+    r2 = parameters.update_parameter_context(
+        r1
+    )
+    assert isinstance(r2, ParameterContextEntity)
+    assert r2.component.parameters[0].parameter.description == 'Matter'
+
+
+def test_delete_parameter_from_context(regress_nifi, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate()
+    c1.component.parameters.append(
+        parameters.prepare_parameter('Black', 'Lives', 'Matter', True)
+    )
+    _ = parameters.update_parameter_context(
+        c1
+    )
+    r1 = parameters.delete_parameter_from_context(c1, 'Black')
+    assert r1.component.parameters == []
+
+
+def test_upsert_parameter_to_context(regress_nifi, fix_context):
+    if check_version('1.10.0') > 0:
+        pytest.skip("NiFi not 1.10+")
+    c1 = fix_context.generate()
+    r1 = parameters.upsert_parameter_to_context(
+        c1,
+        parameters.prepare_parameter('Black', 'Lives', 'Matter', True)
+    )
+    assert r1.component.parameters[0].parameter.description == 'Matter'


### PR DESCRIPTION
Add support for Parameter Contexts in parameters.py with appropriate tests and fixtures
Update release process in devnotes.rst with additional checks
Rework error raising to provide raise_from support inline with newer Python best practices, added future to requirements.txt in support of this for Py2 and Py3 intercompatibility
Add greedy control support to canvas.get_processor_type
Add checks to canvas.create_processor for correct user submissions
Improve get by ID behavior to correctly return None when an invalid ID is submitted (previously raised a 404)
Add canvas.get_controller_type to fetch a single controller type, previously only a listing option was provided
Add utils.enforce_min_version to improve controls when a feature is not available in older versions of NiFi as Paramter Contexts were only introduced in 1.10.0
Minor test case and style improvements
Add refresh default to canvas.update_process_group
Add convenience methods to parameters.py to assign and remove a Parameter Context to a Process Group, with appropriate tests
Minor coding style improvements