### PR TITLE
Fix issue 229

### DIFF
--- a/nipyapi/__init__.py
+++ b/nipyapi/__init__.py
@@ -9,7 +9,7 @@ import importlib
 
 __author__ = """Daniel Chaffelson"""
 __email__ = 'chaffelson@gmail.com'
-__version__ = '0.16.0'
+__version__ = '0.16.1'
 __all__ = ['canvas', 'system', 'templates', 'config', 'nifi', 'registry',
            'versioning', 'demo', 'utils', 'security', 'parameters']
 

--- a/resources/docker/tox-full/docker-compose.yml
+++ b/resources/docker/tox-full/docker-compose.yml
@@ -30,6 +30,12 @@ services:
     hostname: nifi
     ports:
       - "8080:8080"
+  nifidev:
+    image: apache/nifi:1.12.1
+    container_name: nifidev
+    hostname: nifidev
+    ports:
+      - "8081:8080"
   registry-010:
     image: apache/nifi-registry:0.1.0
     container_name: registry-010
@@ -54,3 +60,11 @@ services:
       - "18080:18080"
     environment:
       - NIFI_REGISTRY_WEB_HTTP_PORT=18080
+  registrydev:
+    image: apache/nifi-registry:0.7.0
+    container_name: registrydev
+    hostname: registrydev
+    ports:
+      - "18081:18081"
+    environment:
+      - NIFI_REGISTRY_WEB_HTTP_PORT=18081

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.0
+current_version = 0.16.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('docs/history.rst') as history_file:
     history = history_file.read()
 
-proj_version = '0.16.0'
+proj_version = '0.16.1'
 
 with open('requirements.txt') as reqs_file:
     requirements = reqs_file.read().splitlines()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -594,8 +594,8 @@ def fixture_flow_serde(request, tmpdir, fix_ver_flow):
         'FixtureFlowSerde',
         getattr(fix_ver_flow, '_fields') + ('filepath', 'json', 'yaml', 'raw')
     )
-    f_filepath = str(tmpdir.mkdir(test_ver_export_tmpdir)\
-        .join(test_ver_export_filename))
+    f_filepath = str(tmpdir.mkdir(test_ver_export_tmpdir)
+                     .join(test_ver_export_filename))
     f_raw = nipyapi.versioning.get_flow_version(
         bucket_id=fix_ver_flow.bucket.identifier,
         flow_id=fix_ver_flow.flow.identifier,


### PR DESCRIPTION
Found that importing a versioned flow was stripping out fields added in newer versions of NiFi.
Also found that older versions of registry do not support these Fields and were also being silently stripped, implemented version checks and warnings for old registry or NiFi not supporting Parameters.