### PR TITLE
add socks proxy support

### DIFF
--- a/nipyapi/nifi/rest.py
+++ b/nipyapi/nifi/rest.py
@@ -92,8 +92,19 @@ class RESTClientObject(object):
         proxy = Configuration().proxy
 
         # https pool manager
-        if proxy:
+        if proxy and "socks" not in str(proxy):
             self.pool_manager = urllib3.ProxyManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file,
+                ssl_context=ssl_context,
+                proxy_url=proxy
+            )
+        elif proxy and "socks" in str(proxy):
+            self.pool_manager = urllib3.contrib.socks.SOCKSProxyManager(
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ lxml>=4.1.1,<4.4.0  # pyup: ignore
 requests[security]>=2.18
 # urllib3, cryptography are handled by requests
 
+# Socks Proxy
+pysocks>=1.7.1
+
 # Import Export and Utils implementation
 ruamel.yaml==0.16.12
 

--- a/resources/client_gen/swagger_templates/rest.mustache
+++ b/resources/client_gen/swagger_templates/rest.mustache
@@ -83,8 +83,19 @@ class RESTClientObject(object):
         proxy = Configuration().proxy
 
         # https pool manager
-        if proxy:
+        if proxy and "socks" not in str(proxy):
             self.pool_manager = urllib3.ProxyManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file,
+                ssl_context=ssl_context,
+                proxy_url=proxy
+            )
+        elif proxy and "socks" in str(proxy):
+            self.pool_manager = urllib3.contrib.socks.SOCKSProxyManager(
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,


### PR DESCRIPTION
This PR adds support for SOCKS proxies. It uses the "proxy" parameter for SOCKS proxies and distinguishes SOCKS proxies from other proxies by the occurence of "socks" in the proxy url.
urllib3 is used for SOCKS proxies which uses pysocks for its implementation. See https://urllib3.readthedocs.io/en/latest/reference/contrib/socks.html