### PR TITLE
Fix Authentication issues introduced in 0.14.3, and other minor fixes

### DIFF
--- a/nipyapi/nifi/api_client.py
+++ b/nipyapi/nifi/api_client.py
@@ -523,6 +523,8 @@ class ApiClient(object):
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'
                     )
+        if config.force_basic_auth:
+            headers['Authorization'] = config.get_basic_auth_token()
 
     def __deserialize_file(self, response):
         """

--- a/nipyapi/nifi/apis/access_api.py
+++ b/nipyapi/nifi/apis/access_api.py
@@ -130,7 +130,7 @@ class AccessApi(object):
             select_header_content_type(['application/x-www-form-urlencoded'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/token', 'POST',
                                         path_params,
@@ -228,7 +228,7 @@ class AccessApi(object):
             select_header_content_type(['text/plain'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/kerberos', 'POST',
                                         path_params,
@@ -326,7 +326,7 @@ class AccessApi(object):
             select_header_content_type(['application/x-www-form-urlencoded'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/download-token', 'POST',
                                         path_params,
@@ -424,7 +424,7 @@ class AccessApi(object):
             select_header_content_type(['application/x-www-form-urlencoded'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/ui-extension-token', 'POST',
                                         path_params,
@@ -522,7 +522,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access', 'GET',
                                         path_params,
@@ -542,7 +542,7 @@ class AccessApi(object):
     def get_login_config(self, **kwargs):
         """
         Retrieves the access configuration for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -567,7 +567,7 @@ class AccessApi(object):
     def get_login_config_with_http_info(self, **kwargs):
         """
         Retrieves the access configuration for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -620,7 +620,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/config', 'GET',
                                         path_params,
@@ -718,7 +718,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/knox/callback', 'GET',
                                         path_params,
@@ -816,7 +816,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/knox/logout', 'GET',
                                         path_params,
@@ -914,7 +914,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/knox/request', 'GET',
                                         path_params,
@@ -1012,7 +1012,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/logout', 'DELETE',
                                         path_params,
@@ -1110,7 +1110,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/oidc/callback', 'GET',
                                         path_params,
@@ -1208,7 +1208,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/oidc/exchange', 'POST',
                                         path_params,
@@ -1306,7 +1306,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/oidc/logout', 'GET',
                                         path_params,
@@ -1404,7 +1404,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/oidc/request', 'GET',
                                         path_params,

--- a/nipyapi/nifi/apis/connections_api.py
+++ b/nipyapi/nifi/apis/connections_api.py
@@ -43,7 +43,7 @@ class ConnectionsApi(object):
     def delete_connection(self, id, **kwargs):
         """
         Deletes a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -72,7 +72,7 @@ class ConnectionsApi(object):
     def delete_connection_with_http_info(self, id, **kwargs):
         """
         Deletes a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -141,7 +141,7 @@ class ConnectionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/connections/{id}', 'DELETE',
                                         path_params,
@@ -161,7 +161,7 @@ class ConnectionsApi(object):
     def get_connection(self, id, **kwargs):
         """
         Gets a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -187,7 +187,7 @@ class ConnectionsApi(object):
     def get_connection_with_http_info(self, id, **kwargs):
         """
         Gets a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -247,7 +247,7 @@ class ConnectionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/connections/{id}', 'GET',
                                         path_params,
@@ -267,7 +267,7 @@ class ConnectionsApi(object):
     def update_connection(self, id, body, **kwargs):
         """
         Updates a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -294,7 +294,7 @@ class ConnectionsApi(object):
     def update_connection_with_http_info(self, id, body, **kwargs):
         """
         Updates a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -360,7 +360,7 @@ class ConnectionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/connections/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/controller_api.py
+++ b/nipyapi/nifi/apis/controller_api.py
@@ -43,7 +43,7 @@ class ControllerApi(object):
     def create_bulletin(self, body, **kwargs):
         """
         Creates a new bulletin
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class ControllerApi(object):
     def create_bulletin_with_http_info(self, body, **kwargs):
         """
         Creates a new bulletin
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/bulletin', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class ControllerApi(object):
     def create_controller_service(self, body, **kwargs):
         """
         Creates a new controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -175,7 +175,7 @@ class ControllerApi(object):
     def create_controller_service_with_http_info(self, body, **kwargs):
         """
         Creates a new controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -235,7 +235,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/controller-services', 'POST',
                                         path_params,
@@ -255,7 +255,7 @@ class ControllerApi(object):
     def create_registry_client(self, body, **kwargs):
         """
         Creates a new registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -281,7 +281,7 @@ class ControllerApi(object):
     def create_registry_client_with_http_info(self, body, **kwargs):
         """
         Creates a new registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -341,7 +341,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/registry-clients', 'POST',
                                         path_params,
@@ -361,7 +361,7 @@ class ControllerApi(object):
     def create_reporting_task(self, body, **kwargs):
         """
         Creates a new reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -387,7 +387,7 @@ class ControllerApi(object):
     def create_reporting_task_with_http_info(self, body, **kwargs):
         """
         Creates a new reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -447,7 +447,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/reporting-tasks', 'POST',
                                         path_params,
@@ -467,7 +467,7 @@ class ControllerApi(object):
     def delete_history(self, end_date, **kwargs):
         """
         Purges history
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -493,7 +493,7 @@ class ControllerApi(object):
     def delete_history_with_http_info(self, end_date, **kwargs):
         """
         Purges history
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -553,7 +553,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/history', 'DELETE',
                                         path_params,
@@ -573,7 +573,7 @@ class ControllerApi(object):
     def delete_node(self, id, **kwargs):
         """
         Removes a node from the cluster
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -599,7 +599,7 @@ class ControllerApi(object):
     def delete_node_with_http_info(self, id, **kwargs):
         """
         Removes a node from the cluster
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -659,7 +659,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/cluster/nodes/{id}', 'DELETE',
                                         path_params,
@@ -679,7 +679,7 @@ class ControllerApi(object):
     def delete_registry_client(self, id, **kwargs):
         """
         Deletes a registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -708,7 +708,7 @@ class ControllerApi(object):
     def delete_registry_client_with_http_info(self, id, **kwargs):
         """
         Deletes a registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -777,7 +777,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/registry-clients/{id}', 'DELETE',
                                         path_params,
@@ -875,7 +875,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/cluster', 'GET',
                                         path_params,
@@ -895,7 +895,7 @@ class ControllerApi(object):
     def get_controller_config(self, **kwargs):
         """
         Retrieves the configuration for this NiFi Controller
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -920,7 +920,7 @@ class ControllerApi(object):
     def get_controller_config_with_http_info(self, **kwargs):
         """
         Retrieves the configuration for this NiFi Controller
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -973,7 +973,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/config', 'GET',
                                         path_params,
@@ -993,7 +993,7 @@ class ControllerApi(object):
     def get_node(self, id, **kwargs):
         """
         Gets a node in the cluster
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1019,7 +1019,7 @@ class ControllerApi(object):
     def get_node_with_http_info(self, id, **kwargs):
         """
         Gets a node in the cluster
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1079,7 +1079,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/cluster/nodes/{id}', 'GET',
                                         path_params,
@@ -1099,7 +1099,7 @@ class ControllerApi(object):
     def get_registry_client(self, id, **kwargs):
         """
         Gets a registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1125,7 +1125,7 @@ class ControllerApi(object):
     def get_registry_client_with_http_info(self, id, **kwargs):
         """
         Gets a registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1185,7 +1185,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/registry-clients/{id}', 'GET',
                                         path_params,
@@ -1205,7 +1205,7 @@ class ControllerApi(object):
     def get_registry_clients(self, **kwargs):
         """
         Gets the listing of available registry clients
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1230,7 +1230,7 @@ class ControllerApi(object):
     def get_registry_clients_with_http_info(self, **kwargs):
         """
         Gets the listing of available registry clients
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1283,7 +1283,7 @@ class ControllerApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/registry-clients', 'GET',
                                         path_params,
@@ -1303,7 +1303,7 @@ class ControllerApi(object):
     def update_controller_config(self, body, **kwargs):
         """
         Retrieves the configuration for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1329,7 +1329,7 @@ class ControllerApi(object):
     def update_controller_config_with_http_info(self, body, **kwargs):
         """
         Retrieves the configuration for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1389,7 +1389,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/config', 'PUT',
                                         path_params,
@@ -1409,7 +1409,7 @@ class ControllerApi(object):
     def update_node(self, id, body, **kwargs):
         """
         Updates a node in the cluster
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1436,7 +1436,7 @@ class ControllerApi(object):
     def update_node_with_http_info(self, id, body, **kwargs):
         """
         Updates a node in the cluster
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1502,7 +1502,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/cluster/nodes/{id}', 'PUT',
                                         path_params,
@@ -1522,7 +1522,7 @@ class ControllerApi(object):
     def update_registry_client(self, id, body, **kwargs):
         """
         Updates a registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1549,7 +1549,7 @@ class ControllerApi(object):
     def update_registry_client_with_http_info(self, id, body, **kwargs):
         """
         Updates a registry client
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1615,7 +1615,7 @@ class ControllerApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller/registry-clients/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/controller_services_api.py
+++ b/nipyapi/nifi/apis/controller_services_api.py
@@ -43,7 +43,7 @@ class ControllerServicesApi(object):
     def clear_state(self, id, **kwargs):
         """
         Clears the state for a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class ControllerServicesApi(object):
     def clear_state_with_http_info(self, id, **kwargs):
         """
         Clears the state for a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}/state/clear-requests', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class ControllerServicesApi(object):
     def get_controller_service(self, id, **kwargs):
         """
         Gets a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -175,7 +175,7 @@ class ControllerServicesApi(object):
     def get_controller_service_with_http_info(self, id, **kwargs):
         """
         Gets a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -235,7 +235,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}', 'GET',
                                         path_params,
@@ -255,7 +255,7 @@ class ControllerServicesApi(object):
     def get_controller_service_references(self, id, **kwargs):
         """
         Gets a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -281,7 +281,7 @@ class ControllerServicesApi(object):
     def get_controller_service_references_with_http_info(self, id, **kwargs):
         """
         Gets a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -341,7 +341,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}/references', 'GET',
                                         path_params,
@@ -361,7 +361,7 @@ class ControllerServicesApi(object):
     def get_property_descriptor(self, id, property_name, **kwargs):
         """
         Gets a controller service property descriptor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -388,7 +388,7 @@ class ControllerServicesApi(object):
     def get_property_descriptor_with_http_info(self, id, property_name, **kwargs):
         """
         Gets a controller service property descriptor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -454,7 +454,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}/descriptors', 'GET',
                                         path_params,
@@ -474,7 +474,7 @@ class ControllerServicesApi(object):
     def get_state(self, id, **kwargs):
         """
         Gets the state for a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -500,7 +500,7 @@ class ControllerServicesApi(object):
     def get_state_with_http_info(self, id, **kwargs):
         """
         Gets the state for a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -560,7 +560,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}/state', 'GET',
                                         path_params,
@@ -580,7 +580,7 @@ class ControllerServicesApi(object):
     def remove_controller_service(self, id, **kwargs):
         """
         Deletes a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -609,7 +609,7 @@ class ControllerServicesApi(object):
     def remove_controller_service_with_http_info(self, id, **kwargs):
         """
         Deletes a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -678,7 +678,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}', 'DELETE',
                                         path_params,
@@ -698,7 +698,7 @@ class ControllerServicesApi(object):
     def update_controller_service(self, id, body, **kwargs):
         """
         Updates a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -725,7 +725,7 @@ class ControllerServicesApi(object):
     def update_controller_service_with_http_info(self, id, body, **kwargs):
         """
         Updates a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -791,7 +791,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}', 'PUT',
                                         path_params,
@@ -811,7 +811,7 @@ class ControllerServicesApi(object):
     def update_controller_service_references(self, id, body, **kwargs):
         """
         Updates a controller services references
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -838,7 +838,7 @@ class ControllerServicesApi(object):
     def update_controller_service_references_with_http_info(self, id, body, **kwargs):
         """
         Updates a controller services references
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -904,7 +904,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}/references', 'PUT',
                                         path_params,
@@ -924,7 +924,7 @@ class ControllerServicesApi(object):
     def update_run_status(self, id, body, **kwargs):
         """
         Updates run status of a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -951,7 +951,7 @@ class ControllerServicesApi(object):
     def update_run_status_with_http_info(self, id, body, **kwargs):
         """
         Updates run status of a controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1017,7 +1017,7 @@ class ControllerServicesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/controller-services/{id}/run-status', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/counters_api.py
+++ b/nipyapi/nifi/apis/counters_api.py
@@ -130,7 +130,7 @@ class CountersApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/counters', 'GET',
                                         path_params,
@@ -236,7 +236,7 @@ class CountersApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/counters/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/data_transfer_api.py
+++ b/nipyapi/nifi/apis/data_transfer_api.py
@@ -43,7 +43,7 @@ class DataTransferApi(object):
     def commit_input_port_transaction(self, response_code, port_id, transaction_id, **kwargs):
         """
         Commit or cancel the specified transaction
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -71,7 +71,7 @@ class DataTransferApi(object):
     def commit_input_port_transaction_with_http_info(self, response_code, port_id, transaction_id, **kwargs):
         """
         Commit or cancel the specified transaction
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -143,7 +143,7 @@ class DataTransferApi(object):
             select_header_content_type(['application/octet-stream'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/input-ports/{portId}/transactions/{transactionId}', 'DELETE',
                                         path_params,
@@ -163,7 +163,7 @@ class DataTransferApi(object):
     def commit_output_port_transaction(self, response_code, checksum, port_id, transaction_id, **kwargs):
         """
         Commit or cancel the specified transaction
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -192,7 +192,7 @@ class DataTransferApi(object):
     def commit_output_port_transaction_with_http_info(self, response_code, checksum, port_id, transaction_id, **kwargs):
         """
         Commit or cancel the specified transaction
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -270,7 +270,7 @@ class DataTransferApi(object):
             select_header_content_type(['application/octet-stream'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/output-ports/{portId}/transactions/{transactionId}', 'DELETE',
                                         path_params,
@@ -290,7 +290,7 @@ class DataTransferApi(object):
     def create_port_transaction(self, port_type, port_id, **kwargs):
         """
         Create a transaction to the specified output port or input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -317,7 +317,7 @@ class DataTransferApi(object):
     def create_port_transaction_with_http_info(self, port_type, port_id, **kwargs):
         """
         Create a transaction to the specified output port or input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -379,7 +379,7 @@ class DataTransferApi(object):
             select_header_accept(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/{portType}/{portId}/transactions', 'POST',
                                         path_params,
@@ -399,7 +399,7 @@ class DataTransferApi(object):
     def extend_input_port_transaction_ttl(self, port_id, transaction_id, **kwargs):
         """
         Extend transaction TTL
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -426,7 +426,7 @@ class DataTransferApi(object):
     def extend_input_port_transaction_ttl_with_http_info(self, port_id, transaction_id, **kwargs):
         """
         Extend transaction TTL
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -492,7 +492,7 @@ class DataTransferApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/input-ports/{portId}/transactions/{transactionId}', 'PUT',
                                         path_params,
@@ -512,7 +512,7 @@ class DataTransferApi(object):
     def extend_output_port_transaction_ttl(self, port_id, transaction_id, **kwargs):
         """
         Extend transaction TTL
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -539,7 +539,7 @@ class DataTransferApi(object):
     def extend_output_port_transaction_ttl_with_http_info(self, port_id, transaction_id, **kwargs):
         """
         Extend transaction TTL
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -605,7 +605,7 @@ class DataTransferApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/output-ports/{portId}/transactions/{transactionId}', 'PUT',
                                         path_params,
@@ -625,7 +625,7 @@ class DataTransferApi(object):
     def receive_flow_files(self, port_id, transaction_id, **kwargs):
         """
         Transfer flow files to the input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -652,7 +652,7 @@ class DataTransferApi(object):
     def receive_flow_files_with_http_info(self, port_id, transaction_id, **kwargs):
         """
         Transfer flow files to the input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -718,7 +718,7 @@ class DataTransferApi(object):
             select_header_content_type(['application/octet-stream'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/input-ports/{portId}/transactions/{transactionId}/flow-files', 'POST',
                                         path_params,
@@ -738,7 +738,7 @@ class DataTransferApi(object):
     def transfer_flow_files(self, port_id, transaction_id, **kwargs):
         """
         Transfer flow files from the output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -765,7 +765,7 @@ class DataTransferApi(object):
     def transfer_flow_files_with_http_info(self, port_id, transaction_id, **kwargs):
         """
         Transfer flow files from the output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -831,7 +831,7 @@ class DataTransferApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/data-transfer/output-ports/{portId}/transactions/{transactionId}/flow-files', 'GET',
                                         path_params,

--- a/nipyapi/nifi/apis/flow_api.py
+++ b/nipyapi/nifi/apis/flow_api.py
@@ -43,7 +43,7 @@ class FlowApi(object):
     def activate_controller_services(self, id, body, **kwargs):
         """
         Enable or disable Controller Services in the specified Process Group.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -70,7 +70,7 @@ class FlowApi(object):
     def activate_controller_services_with_http_info(self, id, body, **kwargs):
         """
         Enable or disable Controller Services in the specified Process Group.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -136,7 +136,7 @@ class FlowApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/process-groups/{id}/controller-services', 'PUT',
                                         path_params,
@@ -156,7 +156,7 @@ class FlowApi(object):
     def generate_client_id(self, **kwargs):
         """
         Generates a client id.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -181,7 +181,7 @@ class FlowApi(object):
     def generate_client_id_with_http_info(self, **kwargs):
         """
         Generates a client id.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -234,7 +234,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/client-id', 'GET',
                                         path_params,
@@ -254,7 +254,7 @@ class FlowApi(object):
     def get_about_info(self, **kwargs):
         """
         Retrieves details about this NiFi to put in the About dialog
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -279,7 +279,7 @@ class FlowApi(object):
     def get_about_info_with_http_info(self, **kwargs):
         """
         Retrieves details about this NiFi to put in the About dialog
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -332,7 +332,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/about', 'GET',
                                         path_params,
@@ -438,7 +438,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/history/{id}', 'GET',
                                         path_params,
@@ -458,7 +458,7 @@ class FlowApi(object):
     def get_banners(self, **kwargs):
         """
         Retrieves the banners for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -483,7 +483,7 @@ class FlowApi(object):
     def get_banners_with_http_info(self, **kwargs):
         """
         Retrieves the banners for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -536,7 +536,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/banners', 'GET',
                                         path_params,
@@ -556,7 +556,7 @@ class FlowApi(object):
     def get_buckets(self, id, **kwargs):
         """
         Gets the buckets from the specified registry for the current user
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -582,7 +582,7 @@ class FlowApi(object):
     def get_buckets_with_http_info(self, id, **kwargs):
         """
         Gets the buckets from the specified registry for the current user
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -642,7 +642,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/registries/{id}/buckets', 'GET',
                                         path_params,
@@ -662,7 +662,7 @@ class FlowApi(object):
     def get_bulletin_board(self, **kwargs):
         """
         Gets current bulletins
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -693,7 +693,7 @@ class FlowApi(object):
     def get_bulletin_board_with_http_info(self, **kwargs):
         """
         Gets current bulletins
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -765,7 +765,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/bulletin-board', 'GET',
                                         path_params,
@@ -785,7 +785,7 @@ class FlowApi(object):
     def get_bulletins(self, **kwargs):
         """
         Retrieves Controller level bulletins
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -810,7 +810,7 @@ class FlowApi(object):
     def get_bulletins_with_http_info(self, **kwargs):
         """
         Retrieves Controller level bulletins
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -863,7 +863,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/controller/bulletins', 'GET',
                                         path_params,
@@ -883,7 +883,7 @@ class FlowApi(object):
     def get_cluster_summary(self, **kwargs):
         """
         The cluster summary for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -908,7 +908,7 @@ class FlowApi(object):
     def get_cluster_summary_with_http_info(self, **kwargs):
         """
         The cluster summary for this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -961,7 +961,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/cluster/summary', 'GET',
                                         path_params,
@@ -1067,7 +1067,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/history/components/{componentId}', 'GET',
                                         path_params,
@@ -1087,7 +1087,7 @@ class FlowApi(object):
     def get_connection_statistics(self, id, **kwargs):
         """
         Gets statistics for a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1115,7 +1115,7 @@ class FlowApi(object):
     def get_connection_statistics_with_http_info(self, id, **kwargs):
         """
         Gets statistics for a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1181,7 +1181,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/connections/{id}/statistics', 'GET',
                                         path_params,
@@ -1201,7 +1201,7 @@ class FlowApi(object):
     def get_connection_status(self, id, **kwargs):
         """
         Gets status for a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1229,7 +1229,7 @@ class FlowApi(object):
     def get_connection_status_with_http_info(self, id, **kwargs):
         """
         Gets status for a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1295,7 +1295,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/connections/{id}/status', 'GET',
                                         path_params,
@@ -1315,7 +1315,7 @@ class FlowApi(object):
     def get_connection_status_history(self, id, **kwargs):
         """
         Gets the status history for a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1341,7 +1341,7 @@ class FlowApi(object):
     def get_connection_status_history_with_http_info(self, id, **kwargs):
         """
         Gets the status history for a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1401,7 +1401,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/connections/{id}/status/history', 'GET',
                                         path_params,
@@ -1528,7 +1528,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/controller-service-types', 'GET',
                                         path_params,
@@ -1548,7 +1548,7 @@ class FlowApi(object):
     def get_controller_services_from_controller(self, **kwargs):
         """
         Gets controller services for reporting tasks
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1573,7 +1573,7 @@ class FlowApi(object):
     def get_controller_services_from_controller_with_http_info(self, **kwargs):
         """
         Gets controller services for reporting tasks
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1626,7 +1626,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/controller/controller-services', 'GET',
                                         path_params,
@@ -1646,7 +1646,7 @@ class FlowApi(object):
     def get_controller_services_from_group(self, id, **kwargs):
         """
         Gets all controller services
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1674,7 +1674,7 @@ class FlowApi(object):
     def get_controller_services_from_group_with_http_info(self, id, **kwargs):
         """
         Gets all controller services
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1740,7 +1740,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/process-groups/{id}/controller-services', 'GET',
                                         path_params,
@@ -1760,7 +1760,7 @@ class FlowApi(object):
     def get_controller_status(self, **kwargs):
         """
         Gets the current status of this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1785,7 +1785,7 @@ class FlowApi(object):
     def get_controller_status_with_http_info(self, **kwargs):
         """
         Gets the current status of this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1838,7 +1838,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/status', 'GET',
                                         path_params,
@@ -1858,7 +1858,7 @@ class FlowApi(object):
     def get_current_user(self, **kwargs):
         """
         Retrieves the user identity of the user making the request
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1883,7 +1883,7 @@ class FlowApi(object):
     def get_current_user_with_http_info(self, **kwargs):
         """
         Retrieves the user identity of the user making the request
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1936,7 +1936,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/current-user', 'GET',
                                         path_params,
@@ -1956,7 +1956,7 @@ class FlowApi(object):
     def get_flow(self, id, **kwargs):
         """
         Gets a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1982,7 +1982,7 @@ class FlowApi(object):
     def get_flow_with_http_info(self, id, **kwargs):
         """
         Gets a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2042,7 +2042,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/process-groups/{id}', 'GET',
                                         path_params,
@@ -2062,7 +2062,7 @@ class FlowApi(object):
     def get_flow_config(self, **kwargs):
         """
         Retrieves the configuration for this NiFi flow
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2087,7 +2087,7 @@ class FlowApi(object):
     def get_flow_config_with_http_info(self, **kwargs):
         """
         Retrieves the configuration for this NiFi flow
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2140,7 +2140,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/config', 'GET',
                                         path_params,
@@ -2160,7 +2160,7 @@ class FlowApi(object):
     def get_flow_metrics(self, producer, **kwargs):
         """
         Gets all metrics for the flow from a particular node
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2186,7 +2186,7 @@ class FlowApi(object):
     def get_flow_metrics_with_http_info(self, producer, **kwargs):
         """
         Gets all metrics for the flow from a particular node
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2246,7 +2246,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/metrics/{producer}', 'GET',
                                         path_params,
@@ -2266,7 +2266,7 @@ class FlowApi(object):
     def get_flows(self, registry_id, bucket_id, **kwargs):
         """
         Gets the flows from the specified registry and bucket for the current user
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2293,7 +2293,7 @@ class FlowApi(object):
     def get_flows_with_http_info(self, registry_id, bucket_id, **kwargs):
         """
         Gets the flows from the specified registry and bucket for the current user
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2359,7 +2359,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/registries/{registry-id}/buckets/{bucket-id}/flows', 'GET',
                                         path_params,
@@ -2379,7 +2379,7 @@ class FlowApi(object):
     def get_input_port_status(self, id, **kwargs):
         """
         Gets status for an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2407,7 +2407,7 @@ class FlowApi(object):
     def get_input_port_status_with_http_info(self, id, **kwargs):
         """
         Gets status for an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2473,7 +2473,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/input-ports/{id}/status', 'GET',
                                         path_params,
@@ -2493,7 +2493,7 @@ class FlowApi(object):
     def get_output_port_status(self, id, **kwargs):
         """
         Gets status for an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2521,7 +2521,7 @@ class FlowApi(object):
     def get_output_port_status_with_http_info(self, id, **kwargs):
         """
         Gets status for an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2587,7 +2587,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/output-ports/{id}/status', 'GET',
                                         path_params,
@@ -2607,7 +2607,7 @@ class FlowApi(object):
     def get_parameter_contexts(self, **kwargs):
         """
         Gets all Parameter Contexts
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2632,7 +2632,7 @@ class FlowApi(object):
     def get_parameter_contexts_with_http_info(self, **kwargs):
         """
         Gets all Parameter Contexts
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2685,7 +2685,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/parameter-contexts', 'GET',
                                         path_params,
@@ -2783,7 +2783,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/prioritizers', 'GET',
                                         path_params,
@@ -2901,7 +2901,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/process-groups/{id}/status', 'GET',
                                         path_params,
@@ -2921,7 +2921,7 @@ class FlowApi(object):
     def get_process_group_status_history(self, id, **kwargs):
         """
         Gets status history for a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2947,7 +2947,7 @@ class FlowApi(object):
     def get_process_group_status_history_with_http_info(self, id, **kwargs):
         """
         Gets status history for a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3007,7 +3007,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/process-groups/{id}/status/history', 'GET',
                                         path_params,
@@ -3027,7 +3027,7 @@ class FlowApi(object):
     def get_processor_status(self, id, **kwargs):
         """
         Gets status for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3055,7 +3055,7 @@ class FlowApi(object):
     def get_processor_status_with_http_info(self, id, **kwargs):
         """
         Gets status for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3121,7 +3121,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/processors/{id}/status', 'GET',
                                         path_params,
@@ -3141,7 +3141,7 @@ class FlowApi(object):
     def get_processor_status_history(self, id, **kwargs):
         """
         Gets status history for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3167,7 +3167,7 @@ class FlowApi(object):
     def get_processor_status_history_with_http_info(self, id, **kwargs):
         """
         Gets status history for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3227,7 +3227,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/processors/{id}/status/history', 'GET',
                                         path_params,
@@ -3338,7 +3338,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/processor-types', 'GET',
                                         path_params,
@@ -3358,7 +3358,7 @@ class FlowApi(object):
     def get_registries(self, **kwargs):
         """
         Gets the listing of available registries
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3383,7 +3383,7 @@ class FlowApi(object):
     def get_registries_with_http_info(self, **kwargs):
         """
         Gets the listing of available registries
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3436,7 +3436,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/registries', 'GET',
                                         path_params,
@@ -3456,7 +3456,7 @@ class FlowApi(object):
     def get_remote_process_group_status(self, id, **kwargs):
         """
         Gets status for a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3484,7 +3484,7 @@ class FlowApi(object):
     def get_remote_process_group_status_with_http_info(self, id, **kwargs):
         """
         Gets status for a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3550,7 +3550,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/remote-process-groups/{id}/status', 'GET',
                                         path_params,
@@ -3570,7 +3570,7 @@ class FlowApi(object):
     def get_remote_process_group_status_history(self, id, **kwargs):
         """
         Gets the status history
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3596,7 +3596,7 @@ class FlowApi(object):
     def get_remote_process_group_status_history_with_http_info(self, id, **kwargs):
         """
         Gets the status history
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3656,7 +3656,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/remote-process-groups/{id}/status/history', 'GET',
                                         path_params,
@@ -3767,7 +3767,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/reporting-task-types', 'GET',
                                         path_params,
@@ -3787,7 +3787,7 @@ class FlowApi(object):
     def get_reporting_tasks(self, **kwargs):
         """
         Gets all reporting tasks
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3812,7 +3812,7 @@ class FlowApi(object):
     def get_reporting_tasks_with_http_info(self, **kwargs):
         """
         Gets all reporting tasks
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3865,7 +3865,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/reporting-tasks', 'GET',
                                         path_params,
@@ -3885,7 +3885,7 @@ class FlowApi(object):
     def get_templates(self, **kwargs):
         """
         Gets all templates
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3910,7 +3910,7 @@ class FlowApi(object):
     def get_templates_with_http_info(self, **kwargs):
         """
         Gets all templates
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3963,7 +3963,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/templates', 'GET',
                                         path_params,
@@ -3983,7 +3983,7 @@ class FlowApi(object):
     def get_versions(self, registry_id, bucket_id, flow_id, **kwargs):
         """
         Gets the flow versions from the specified registry and bucket for the specified flow for the current user
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4011,7 +4011,7 @@ class FlowApi(object):
     def get_versions_with_http_info(self, registry_id, bucket_id, flow_id, **kwargs):
         """
         Gets the flow versions from the specified registry and bucket for the specified flow for the current user
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4083,7 +4083,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/registries/{registry-id}/buckets/{bucket-id}/flows/{flow-id}/versions', 'GET',
                                         path_params,
@@ -4220,7 +4220,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/history', 'GET',
                                         path_params,
@@ -4240,7 +4240,7 @@ class FlowApi(object):
     def schedule_components(self, id, body, **kwargs):
         """
         Schedule or unschedule components in the specified Process Group.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4267,7 +4267,7 @@ class FlowApi(object):
     def schedule_components_with_http_info(self, id, body, **kwargs):
         """
         Schedule or unschedule components in the specified Process Group.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4333,7 +4333,7 @@ class FlowApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/process-groups/{id}', 'PUT',
                                         path_params,
@@ -4439,7 +4439,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/cluster/search-results', 'GET',
                                         path_params,
@@ -4546,7 +4546,7 @@ class FlowApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flow/search-results', 'GET',
                                         path_params,

--- a/nipyapi/nifi/apis/flowfile_queues_api.py
+++ b/nipyapi/nifi/apis/flowfile_queues_api.py
@@ -43,7 +43,7 @@ class FlowfileQueuesApi(object):
     def create_drop_request(self, id, **kwargs):
         """
         Creates a request to drop the contents of the queue in this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class FlowfileQueuesApi(object):
     def create_drop_request_with_http_info(self, id, **kwargs):
         """
         Creates a request to drop the contents of the queue in this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/drop-requests', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class FlowfileQueuesApi(object):
     def create_flow_file_listing(self, id, **kwargs):
         """
         Lists the contents of the queue in this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -175,7 +175,7 @@ class FlowfileQueuesApi(object):
     def create_flow_file_listing_with_http_info(self, id, **kwargs):
         """
         Lists the contents of the queue in this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -235,7 +235,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/listing-requests', 'POST',
                                         path_params,
@@ -255,7 +255,7 @@ class FlowfileQueuesApi(object):
     def delete_listing_request(self, id, listing_request_id, **kwargs):
         """
         Cancels and/or removes a request to list the contents of this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -282,7 +282,7 @@ class FlowfileQueuesApi(object):
     def delete_listing_request_with_http_info(self, id, listing_request_id, **kwargs):
         """
         Cancels and/or removes a request to list the contents of this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -348,7 +348,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/listing-requests/{listing-request-id}', 'DELETE',
                                         path_params,
@@ -368,7 +368,7 @@ class FlowfileQueuesApi(object):
     def download_flow_file_content(self, id, flowfile_uuid, **kwargs):
         """
         Gets the content for a FlowFile in a Connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -397,7 +397,7 @@ class FlowfileQueuesApi(object):
     def download_flow_file_content_with_http_info(self, id, flowfile_uuid, **kwargs):
         """
         Gets the content for a FlowFile in a Connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -469,7 +469,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/flowfiles/{flowfile-uuid}/content', 'GET',
                                         path_params,
@@ -489,7 +489,7 @@ class FlowfileQueuesApi(object):
     def get_drop_request(self, id, drop_request_id, **kwargs):
         """
         Gets the current status of a drop request for the specified connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -516,7 +516,7 @@ class FlowfileQueuesApi(object):
     def get_drop_request_with_http_info(self, id, drop_request_id, **kwargs):
         """
         Gets the current status of a drop request for the specified connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -582,7 +582,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/drop-requests/{drop-request-id}', 'GET',
                                         path_params,
@@ -602,7 +602,7 @@ class FlowfileQueuesApi(object):
     def get_flow_file(self, id, flowfile_uuid, **kwargs):
         """
         Gets a FlowFile from a Connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -630,7 +630,7 @@ class FlowfileQueuesApi(object):
     def get_flow_file_with_http_info(self, id, flowfile_uuid, **kwargs):
         """
         Gets a FlowFile from a Connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -699,7 +699,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/flowfiles/{flowfile-uuid}', 'GET',
                                         path_params,
@@ -719,7 +719,7 @@ class FlowfileQueuesApi(object):
     def get_listing_request(self, id, listing_request_id, **kwargs):
         """
         Gets the current status of a listing request for the specified connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -746,7 +746,7 @@ class FlowfileQueuesApi(object):
     def get_listing_request_with_http_info(self, id, listing_request_id, **kwargs):
         """
         Gets the current status of a listing request for the specified connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -812,7 +812,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/listing-requests/{listing-request-id}', 'GET',
                                         path_params,
@@ -832,7 +832,7 @@ class FlowfileQueuesApi(object):
     def remove_drop_request(self, id, drop_request_id, **kwargs):
         """
         Cancels and/or removes a request to drop the contents of this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -859,7 +859,7 @@ class FlowfileQueuesApi(object):
     def remove_drop_request_with_http_info(self, id, drop_request_id, **kwargs):
         """
         Cancels and/or removes a request to drop the contents of this connection.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -925,7 +925,7 @@ class FlowfileQueuesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/flowfile-queues/{id}/drop-requests/{drop-request-id}', 'DELETE',
                                         path_params,

--- a/nipyapi/nifi/apis/funnel_api.py
+++ b/nipyapi/nifi/apis/funnel_api.py
@@ -43,7 +43,7 @@ class FunnelApi(object):
     def get_funnel(self, id, **kwargs):
         """
         Gets a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class FunnelApi(object):
     def get_funnel_with_http_info(self, id, **kwargs):
         """
         Gets a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class FunnelApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/funnels/{id}', 'GET',
                                         path_params,
@@ -149,7 +149,7 @@ class FunnelApi(object):
     def remove_funnel(self, id, **kwargs):
         """
         Deletes a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -178,7 +178,7 @@ class FunnelApi(object):
     def remove_funnel_with_http_info(self, id, **kwargs):
         """
         Deletes a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -247,7 +247,7 @@ class FunnelApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/funnels/{id}', 'DELETE',
                                         path_params,
@@ -267,7 +267,7 @@ class FunnelApi(object):
     def update_funnel(self, id, body, **kwargs):
         """
         Updates a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -294,7 +294,7 @@ class FunnelApi(object):
     def update_funnel_with_http_info(self, id, body, **kwargs):
         """
         Updates a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -360,7 +360,7 @@ class FunnelApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/funnels/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/input_ports_api.py
+++ b/nipyapi/nifi/apis/input_ports_api.py
@@ -43,7 +43,7 @@ class InputPortsApi(object):
     def get_input_port(self, id, **kwargs):
         """
         Gets an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class InputPortsApi(object):
     def get_input_port_with_http_info(self, id, **kwargs):
         """
         Gets an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class InputPortsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/input-ports/{id}', 'GET',
                                         path_params,
@@ -149,7 +149,7 @@ class InputPortsApi(object):
     def remove_input_port(self, id, **kwargs):
         """
         Deletes an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -178,7 +178,7 @@ class InputPortsApi(object):
     def remove_input_port_with_http_info(self, id, **kwargs):
         """
         Deletes an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -247,7 +247,7 @@ class InputPortsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/input-ports/{id}', 'DELETE',
                                         path_params,
@@ -267,7 +267,7 @@ class InputPortsApi(object):
     def update_input_port(self, id, body, **kwargs):
         """
         Updates an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -294,7 +294,7 @@ class InputPortsApi(object):
     def update_input_port_with_http_info(self, id, body, **kwargs):
         """
         Updates an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -360,7 +360,7 @@ class InputPortsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/input-ports/{id}', 'PUT',
                                         path_params,
@@ -380,7 +380,7 @@ class InputPortsApi(object):
     def update_run_status(self, id, body, **kwargs):
         """
         Updates run status of an input-port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -407,7 +407,7 @@ class InputPortsApi(object):
     def update_run_status_with_http_info(self, id, body, **kwargs):
         """
         Updates run status of an input-port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -473,7 +473,7 @@ class InputPortsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/input-ports/{id}/run-status', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/labels_api.py
+++ b/nipyapi/nifi/apis/labels_api.py
@@ -43,7 +43,7 @@ class LabelsApi(object):
     def get_label(self, id, **kwargs):
         """
         Gets a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class LabelsApi(object):
     def get_label_with_http_info(self, id, **kwargs):
         """
         Gets a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class LabelsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/labels/{id}', 'GET',
                                         path_params,
@@ -149,7 +149,7 @@ class LabelsApi(object):
     def remove_label(self, id, **kwargs):
         """
         Deletes a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -178,7 +178,7 @@ class LabelsApi(object):
     def remove_label_with_http_info(self, id, **kwargs):
         """
         Deletes a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -247,7 +247,7 @@ class LabelsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/labels/{id}', 'DELETE',
                                         path_params,
@@ -267,7 +267,7 @@ class LabelsApi(object):
     def update_label(self, id, body, **kwargs):
         """
         Updates a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -294,7 +294,7 @@ class LabelsApi(object):
     def update_label_with_http_info(self, id, body, **kwargs):
         """
         Updates a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -360,7 +360,7 @@ class LabelsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/labels/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/output_ports_api.py
+++ b/nipyapi/nifi/apis/output_ports_api.py
@@ -43,7 +43,7 @@ class OutputPortsApi(object):
     def get_output_port(self, id, **kwargs):
         """
         Gets an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class OutputPortsApi(object):
     def get_output_port_with_http_info(self, id, **kwargs):
         """
         Gets an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class OutputPortsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/output-ports/{id}', 'GET',
                                         path_params,
@@ -149,7 +149,7 @@ class OutputPortsApi(object):
     def remove_output_port(self, id, **kwargs):
         """
         Deletes an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -178,7 +178,7 @@ class OutputPortsApi(object):
     def remove_output_port_with_http_info(self, id, **kwargs):
         """
         Deletes an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -247,7 +247,7 @@ class OutputPortsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/output-ports/{id}', 'DELETE',
                                         path_params,
@@ -267,7 +267,7 @@ class OutputPortsApi(object):
     def update_output_port(self, id, body, **kwargs):
         """
         Updates an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -294,7 +294,7 @@ class OutputPortsApi(object):
     def update_output_port_with_http_info(self, id, body, **kwargs):
         """
         Updates an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -360,7 +360,7 @@ class OutputPortsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/output-ports/{id}', 'PUT',
                                         path_params,
@@ -380,7 +380,7 @@ class OutputPortsApi(object):
     def update_run_status(self, id, body, **kwargs):
         """
         Updates run status of an output-port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -407,7 +407,7 @@ class OutputPortsApi(object):
     def update_run_status_with_http_info(self, id, body, **kwargs):
         """
         Updates run status of an output-port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -473,7 +473,7 @@ class OutputPortsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/output-ports/{id}/run-status', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/parameter_contexts_api.py
+++ b/nipyapi/nifi/apis/parameter_contexts_api.py
@@ -43,7 +43,7 @@ class ParameterContextsApi(object):
     def create_parameter_context(self, body, **kwargs):
         """
         Create a Parameter Context
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class ParameterContextsApi(object):
     def create_parameter_context_with_http_info(self, body, **kwargs):
         """
         Create a Parameter Context
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts', 'POST',
                                         path_params,
@@ -247,7 +247,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{id}', 'DELETE',
                                         path_params,
@@ -364,7 +364,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{contextId}/update-requests/{requestId}', 'DELETE',
                                         path_params,
@@ -481,7 +481,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{contextId}/validation-requests/{id}', 'DELETE',
                                         path_params,
@@ -587,7 +587,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{id}', 'GET',
                                         path_params,
@@ -607,7 +607,7 @@ class ParameterContextsApi(object):
     def get_parameter_context_update(self, context_id, request_id, **kwargs):
         """
         Returns the Update Request with the given ID
-        Returns the Update Request with the given ID. Once an Update Request has been created by performing a POST to /nifi-api/parameter-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures.
+        Returns the Update Request with the given ID. Once an Update Request has been created by performing a POST to /nifi-api/parameter-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures. 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -634,7 +634,7 @@ class ParameterContextsApi(object):
     def get_parameter_context_update_with_http_info(self, context_id, request_id, **kwargs):
         """
         Returns the Update Request with the given ID
-        Returns the Update Request with the given ID. Once an Update Request has been created by performing a POST to /nifi-api/parameter-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures.
+        Returns the Update Request with the given ID. Once an Update Request has been created by performing a POST to /nifi-api/parameter-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures. 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -700,7 +700,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{contextId}/update-requests/{requestId}', 'GET',
                                         path_params,
@@ -720,7 +720,7 @@ class ParameterContextsApi(object):
     def get_validation_request(self, context_id, id, **kwargs):
         """
         Returns the Validation Request with the given ID
-        Returns the Validation Request with the given ID. Once a Validation Request has been created by performing a POST to /nifi-api/validation-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures.
+        Returns the Validation Request with the given ID. Once a Validation Request has been created by performing a POST to /nifi-api/validation-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures. 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -747,7 +747,7 @@ class ParameterContextsApi(object):
     def get_validation_request_with_http_info(self, context_id, id, **kwargs):
         """
         Returns the Validation Request with the given ID
-        Returns the Validation Request with the given ID. Once a Validation Request has been created by performing a POST to /nifi-api/validation-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures.
+        Returns the Validation Request with the given ID. Once a Validation Request has been created by performing a POST to /nifi-api/validation-contexts, that request can subsequently be retrieved via this endpoint, and the request that is fetched will contain the updated state, such as percent complete, the current state of the request, and any failures. 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -813,7 +813,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{contextId}/validation-requests/{id}', 'GET',
                                         path_params,
@@ -926,7 +926,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{contextId}/update-requests', 'POST',
                                         path_params,
@@ -1039,7 +1039,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{contextId}/validation-requests', 'POST',
                                         path_params,
@@ -1152,7 +1152,7 @@ class ParameterContextsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/parameter-contexts/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/policies_api.py
+++ b/nipyapi/nifi/apis/policies_api.py
@@ -43,7 +43,7 @@ class PoliciesApi(object):
     def create_access_policy(self, body, **kwargs):
         """
         Creates an access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class PoliciesApi(object):
     def create_access_policy_with_http_info(self, body, **kwargs):
         """
         Creates an access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class PoliciesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/policies', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class PoliciesApi(object):
     def get_access_policy(self, id, **kwargs):
         """
         Gets an access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -175,7 +175,7 @@ class PoliciesApi(object):
     def get_access_policy_with_http_info(self, id, **kwargs):
         """
         Gets an access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -235,7 +235,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/policies/{id}', 'GET',
                                         path_params,
@@ -350,7 +350,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/policies/{action}/{resource}', 'GET',
                                         path_params,
@@ -370,7 +370,7 @@ class PoliciesApi(object):
     def remove_access_policy(self, id, **kwargs):
         """
         Deletes an access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -399,7 +399,7 @@ class PoliciesApi(object):
     def remove_access_policy_with_http_info(self, id, **kwargs):
         """
         Deletes an access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -468,7 +468,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/policies/{id}', 'DELETE',
                                         path_params,
@@ -488,7 +488,7 @@ class PoliciesApi(object):
     def update_access_policy(self, id, body, **kwargs):
         """
         Updates a access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -515,7 +515,7 @@ class PoliciesApi(object):
     def update_access_policy_with_http_info(self, id, body, **kwargs):
         """
         Updates a access policy
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -581,7 +581,7 @@ class PoliciesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/policies/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/process_groups_api.py
+++ b/nipyapi/nifi/apis/process_groups_api.py
@@ -43,7 +43,7 @@ class ProcessGroupsApi(object):
     def copy_snippet(self, id, body, **kwargs):
         """
         Copies a snippet and discards it.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -70,7 +70,7 @@ class ProcessGroupsApi(object):
     def copy_snippet_with_http_info(self, id, body, **kwargs):
         """
         Copies a snippet and discards it.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -136,7 +136,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/snippet-instance', 'POST',
                                         path_params,
@@ -156,7 +156,7 @@ class ProcessGroupsApi(object):
     def create_connection(self, id, body, **kwargs):
         """
         Creates a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -183,7 +183,7 @@ class ProcessGroupsApi(object):
     def create_connection_with_http_info(self, id, body, **kwargs):
         """
         Creates a connection
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -249,7 +249,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/connections', 'POST',
                                         path_params,
@@ -269,7 +269,7 @@ class ProcessGroupsApi(object):
     def create_controller_service(self, id, body, **kwargs):
         """
         Creates a new controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -296,7 +296,7 @@ class ProcessGroupsApi(object):
     def create_controller_service_with_http_info(self, id, body, **kwargs):
         """
         Creates a new controller service
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -362,7 +362,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/controller-services', 'POST',
                                         path_params,
@@ -382,7 +382,7 @@ class ProcessGroupsApi(object):
     def create_empty_all_connections_request(self, id, **kwargs):
         """
         Creates a request to drop all flowfiles of all connection queues in this process group.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -408,7 +408,7 @@ class ProcessGroupsApi(object):
     def create_empty_all_connections_request_with_http_info(self, id, **kwargs):
         """
         Creates a request to drop all flowfiles of all connection queues in this process group.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -468,7 +468,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/empty-all-connections-requests', 'POST',
                                         path_params,
@@ -488,7 +488,7 @@ class ProcessGroupsApi(object):
     def create_funnel(self, id, body, **kwargs):
         """
         Creates a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -515,7 +515,7 @@ class ProcessGroupsApi(object):
     def create_funnel_with_http_info(self, id, body, **kwargs):
         """
         Creates a funnel
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -581,7 +581,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/funnels', 'POST',
                                         path_params,
@@ -601,7 +601,7 @@ class ProcessGroupsApi(object):
     def create_input_port(self, id, body, **kwargs):
         """
         Creates an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -628,7 +628,7 @@ class ProcessGroupsApi(object):
     def create_input_port_with_http_info(self, id, body, **kwargs):
         """
         Creates an input port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -694,7 +694,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/input-ports', 'POST',
                                         path_params,
@@ -714,7 +714,7 @@ class ProcessGroupsApi(object):
     def create_label(self, id, body, **kwargs):
         """
         Creates a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -741,7 +741,7 @@ class ProcessGroupsApi(object):
     def create_label_with_http_info(self, id, body, **kwargs):
         """
         Creates a label
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -807,7 +807,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/labels', 'POST',
                                         path_params,
@@ -827,7 +827,7 @@ class ProcessGroupsApi(object):
     def create_output_port(self, id, body, **kwargs):
         """
         Creates an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -854,7 +854,7 @@ class ProcessGroupsApi(object):
     def create_output_port_with_http_info(self, id, body, **kwargs):
         """
         Creates an output port
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -920,7 +920,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/output-ports', 'POST',
                                         path_params,
@@ -940,7 +940,7 @@ class ProcessGroupsApi(object):
     def create_process_group(self, id, body, **kwargs):
         """
         Creates a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -967,7 +967,7 @@ class ProcessGroupsApi(object):
     def create_process_group_with_http_info(self, id, body, **kwargs):
         """
         Creates a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1033,7 +1033,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/process-groups', 'POST',
                                         path_params,
@@ -1053,7 +1053,7 @@ class ProcessGroupsApi(object):
     def create_processor(self, id, body, **kwargs):
         """
         Creates a new processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1080,7 +1080,7 @@ class ProcessGroupsApi(object):
     def create_processor_with_http_info(self, id, body, **kwargs):
         """
         Creates a new processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1146,7 +1146,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/processors', 'POST',
                                         path_params,
@@ -1166,7 +1166,7 @@ class ProcessGroupsApi(object):
     def create_remote_process_group(self, id, body, **kwargs):
         """
         Creates a new process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1193,7 +1193,7 @@ class ProcessGroupsApi(object):
     def create_remote_process_group_with_http_info(self, id, body, **kwargs):
         """
         Creates a new process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1259,7 +1259,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/remote-process-groups', 'POST',
                                         path_params,
@@ -1279,7 +1279,7 @@ class ProcessGroupsApi(object):
     def create_template(self, id, body, **kwargs):
         """
         Creates a template and discards the specified snippet.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1306,7 +1306,7 @@ class ProcessGroupsApi(object):
     def create_template_with_http_info(self, id, body, **kwargs):
         """
         Creates a template and discards the specified snippet.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1372,7 +1372,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/templates', 'POST',
                                         path_params,
@@ -1482,7 +1482,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/replace-requests/{id}', 'DELETE',
                                         path_params,
@@ -1599,7 +1599,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{groupId}/variable-registry/update-requests/{updateId}', 'DELETE',
                                         path_params,
@@ -1619,7 +1619,7 @@ class ProcessGroupsApi(object):
     def export_process_group(self, id, **kwargs):
         """
         Gets a process group for download
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1645,7 +1645,7 @@ class ProcessGroupsApi(object):
     def export_process_group_with_http_info(self, id, **kwargs):
         """
         Gets a process group for download
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1705,7 +1705,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/download', 'GET',
                                         path_params,
@@ -1725,7 +1725,7 @@ class ProcessGroupsApi(object):
     def get_connections(self, id, **kwargs):
         """
         Gets all connections
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1751,7 +1751,7 @@ class ProcessGroupsApi(object):
     def get_connections_with_http_info(self, id, **kwargs):
         """
         Gets all connections
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1811,7 +1811,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/connections', 'GET',
                                         path_params,
@@ -1831,7 +1831,7 @@ class ProcessGroupsApi(object):
     def get_drop_all_flowfiles_request(self, id, drop_request_id, **kwargs):
         """
         Gets the current status of a drop all flowfiles request.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1858,7 +1858,7 @@ class ProcessGroupsApi(object):
     def get_drop_all_flowfiles_request_with_http_info(self, id, drop_request_id, **kwargs):
         """
         Gets the current status of a drop all flowfiles request.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1924,7 +1924,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/empty-all-connections-requests/{drop-request-id}', 'GET',
                                         path_params,
@@ -1944,7 +1944,7 @@ class ProcessGroupsApi(object):
     def get_funnels(self, id, **kwargs):
         """
         Gets all funnels
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1970,7 +1970,7 @@ class ProcessGroupsApi(object):
     def get_funnels_with_http_info(self, id, **kwargs):
         """
         Gets all funnels
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2030,7 +2030,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/funnels', 'GET',
                                         path_params,
@@ -2050,7 +2050,7 @@ class ProcessGroupsApi(object):
     def get_input_ports(self, id, **kwargs):
         """
         Gets all input ports
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2076,7 +2076,7 @@ class ProcessGroupsApi(object):
     def get_input_ports_with_http_info(self, id, **kwargs):
         """
         Gets all input ports
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2136,7 +2136,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/input-ports', 'GET',
                                         path_params,
@@ -2156,7 +2156,7 @@ class ProcessGroupsApi(object):
     def get_labels(self, id, **kwargs):
         """
         Gets all labels
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2182,7 +2182,7 @@ class ProcessGroupsApi(object):
     def get_labels_with_http_info(self, id, **kwargs):
         """
         Gets all labels
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2242,7 +2242,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/labels', 'GET',
                                         path_params,
@@ -2262,7 +2262,7 @@ class ProcessGroupsApi(object):
     def get_local_modifications(self, id, **kwargs):
         """
         Gets a list of local modifications to the Process Group since it was last synchronized with the Flow Registry
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2288,7 +2288,7 @@ class ProcessGroupsApi(object):
     def get_local_modifications_with_http_info(self, id, **kwargs):
         """
         Gets a list of local modifications to the Process Group since it was last synchronized with the Flow Registry
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2348,7 +2348,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/local-modifications', 'GET',
                                         path_params,
@@ -2368,7 +2368,7 @@ class ProcessGroupsApi(object):
     def get_output_ports(self, id, **kwargs):
         """
         Gets all output ports
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2394,7 +2394,7 @@ class ProcessGroupsApi(object):
     def get_output_ports_with_http_info(self, id, **kwargs):
         """
         Gets all output ports
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2454,7 +2454,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/output-ports', 'GET',
                                         path_params,
@@ -2474,7 +2474,7 @@ class ProcessGroupsApi(object):
     def get_process_group(self, id, **kwargs):
         """
         Gets a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2500,7 +2500,7 @@ class ProcessGroupsApi(object):
     def get_process_group_with_http_info(self, id, **kwargs):
         """
         Gets a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2560,7 +2560,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}', 'GET',
                                         path_params,
@@ -2580,7 +2580,7 @@ class ProcessGroupsApi(object):
     def get_process_groups(self, id, **kwargs):
         """
         Gets all process groups
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2606,7 +2606,7 @@ class ProcessGroupsApi(object):
     def get_process_groups_with_http_info(self, id, **kwargs):
         """
         Gets all process groups
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2666,7 +2666,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/process-groups', 'GET',
                                         path_params,
@@ -2686,7 +2686,7 @@ class ProcessGroupsApi(object):
     def get_processors(self, id, **kwargs):
         """
         Gets all processors
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2713,7 +2713,7 @@ class ProcessGroupsApi(object):
     def get_processors_with_http_info(self, id, **kwargs):
         """
         Gets all processors
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2776,7 +2776,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/processors', 'GET',
                                         path_params,
@@ -2796,7 +2796,7 @@ class ProcessGroupsApi(object):
     def get_remote_process_groups(self, id, **kwargs):
         """
         Gets all remote process groups
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2822,7 +2822,7 @@ class ProcessGroupsApi(object):
     def get_remote_process_groups_with_http_info(self, id, **kwargs):
         """
         Gets all remote process groups
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -2882,7 +2882,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/remote-process-groups', 'GET',
                                         path_params,
@@ -2988,7 +2988,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/replace-requests/{id}', 'GET',
                                         path_params,
@@ -3098,7 +3098,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/variable-registry', 'GET',
                                         path_params,
@@ -3211,7 +3211,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{groupId}/variable-registry/update-requests/{updateId}', 'GET',
                                         path_params,
@@ -3231,7 +3231,7 @@ class ProcessGroupsApi(object):
     def import_template(self, id, **kwargs):
         """
         Imports a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3257,7 +3257,7 @@ class ProcessGroupsApi(object):
     def import_template_with_http_info(self, id, **kwargs):
         """
         Imports a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3317,7 +3317,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/xml'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/templates/import', 'POST',
                                         path_params,
@@ -3430,7 +3430,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/replace-requests', 'POST',
                                         path_params,
@@ -3450,7 +3450,7 @@ class ProcessGroupsApi(object):
     def instantiate_template(self, id, body, **kwargs):
         """
         Instantiates a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3477,7 +3477,7 @@ class ProcessGroupsApi(object):
     def instantiate_template_with_http_info(self, id, body, **kwargs):
         """
         Instantiates a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3543,7 +3543,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/template-instance', 'POST',
                                         path_params,
@@ -3563,7 +3563,7 @@ class ProcessGroupsApi(object):
     def remove_drop_request(self, id, drop_request_id, **kwargs):
         """
         Cancels and/or removes a request to drop all flowfiles.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3590,7 +3590,7 @@ class ProcessGroupsApi(object):
     def remove_drop_request_with_http_info(self, id, drop_request_id, **kwargs):
         """
         Cancels and/or removes a request to drop all flowfiles.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3656,7 +3656,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/empty-all-connections-requests/{drop-request-id}', 'DELETE',
                                         path_params,
@@ -3676,7 +3676,7 @@ class ProcessGroupsApi(object):
     def remove_process_group(self, id, **kwargs):
         """
         Deletes a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3705,7 +3705,7 @@ class ProcessGroupsApi(object):
     def remove_process_group_with_http_info(self, id, **kwargs):
         """
         Deletes a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -3774,7 +3774,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}', 'DELETE',
                                         path_params,
@@ -3887,7 +3887,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/flow-contents', 'PUT',
                                         path_params,
@@ -4000,7 +4000,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/variable-registry/update-requests', 'POST',
                                         path_params,
@@ -4020,7 +4020,7 @@ class ProcessGroupsApi(object):
     def update_process_group(self, id, body, **kwargs):
         """
         Updates a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4047,7 +4047,7 @@ class ProcessGroupsApi(object):
     def update_process_group_with_http_info(self, id, body, **kwargs):
         """
         Updates a process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4113,7 +4113,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}', 'PUT',
                                         path_params,
@@ -4226,7 +4226,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/variable-registry', 'PUT',
                                         path_params,
@@ -4246,7 +4246,7 @@ class ProcessGroupsApi(object):
     def upload_template(self, id, template, **kwargs):
         """
         Uploads a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4274,7 +4274,7 @@ class ProcessGroupsApi(object):
     def upload_template_with_http_info(self, id, template, **kwargs):
         """
         Uploads a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -4343,7 +4343,7 @@ class ProcessGroupsApi(object):
             select_header_content_type(['multipart/form-data'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/process-groups/{id}/templates/upload', 'POST',
                                         path_params,

--- a/nipyapi/nifi/apis/processors_api.py
+++ b/nipyapi/nifi/apis/processors_api.py
@@ -43,7 +43,7 @@ class ProcessorsApi(object):
     def clear_state(self, id, **kwargs):
         """
         Clears the state for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class ProcessorsApi(object):
     def clear_state_with_http_info(self, id, **kwargs):
         """
         Clears the state for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}/state/clear-requests', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class ProcessorsApi(object):
     def delete_processor(self, id, **kwargs):
         """
         Deletes a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -178,7 +178,7 @@ class ProcessorsApi(object):
     def delete_processor_with_http_info(self, id, **kwargs):
         """
         Deletes a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -247,7 +247,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}', 'DELETE',
                                         path_params,
@@ -267,7 +267,7 @@ class ProcessorsApi(object):
     def get_processor(self, id, **kwargs):
         """
         Gets a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -293,7 +293,7 @@ class ProcessorsApi(object):
     def get_processor_with_http_info(self, id, **kwargs):
         """
         Gets a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -353,7 +353,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}', 'GET',
                                         path_params,
@@ -459,7 +459,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}/diagnostics', 'GET',
                                         path_params,
@@ -479,7 +479,7 @@ class ProcessorsApi(object):
     def get_processor_run_status_details(self, **kwargs):
         """
         Submits a query to retrieve the run status details of all processors that are in the given list of Processor IDs
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -505,7 +505,7 @@ class ProcessorsApi(object):
     def get_processor_run_status_details_with_http_info(self, **kwargs):
         """
         Submits a query to retrieve the run status details of all processors that are in the given list of Processor IDs
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -562,7 +562,7 @@ class ProcessorsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/run-status-details/queries', 'POST',
                                         path_params,
@@ -582,7 +582,7 @@ class ProcessorsApi(object):
     def get_property_descriptor(self, id, property_name, **kwargs):
         """
         Gets the descriptor for a processor property
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -610,7 +610,7 @@ class ProcessorsApi(object):
     def get_property_descriptor_with_http_info(self, id, property_name, **kwargs):
         """
         Gets the descriptor for a processor property
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -679,7 +679,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}/descriptors', 'GET',
                                         path_params,
@@ -699,7 +699,7 @@ class ProcessorsApi(object):
     def get_state(self, id, **kwargs):
         """
         Gets the state for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -725,7 +725,7 @@ class ProcessorsApi(object):
     def get_state_with_http_info(self, id, **kwargs):
         """
         Gets the state for a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -785,7 +785,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}/state', 'GET',
                                         path_params,
@@ -805,7 +805,7 @@ class ProcessorsApi(object):
     def terminate_processor(self, id, **kwargs):
         """
         Terminates a processor, essentially \"deleting\" its threads and any active tasks
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -831,7 +831,7 @@ class ProcessorsApi(object):
     def terminate_processor_with_http_info(self, id, **kwargs):
         """
         Terminates a processor, essentially \"deleting\" its threads and any active tasks
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -891,7 +891,7 @@ class ProcessorsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}/threads', 'DELETE',
                                         path_params,
@@ -911,7 +911,7 @@ class ProcessorsApi(object):
     def update_processor(self, id, body, **kwargs):
         """
         Updates a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -938,7 +938,7 @@ class ProcessorsApi(object):
     def update_processor_with_http_info(self, id, body, **kwargs):
         """
         Updates a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1004,7 +1004,7 @@ class ProcessorsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}', 'PUT',
                                         path_params,
@@ -1024,7 +1024,7 @@ class ProcessorsApi(object):
     def update_run_status(self, id, body, **kwargs):
         """
         Updates run status of a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1051,7 +1051,7 @@ class ProcessorsApi(object):
     def update_run_status_with_http_info(self, id, body, **kwargs):
         """
         Updates run status of a processor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1117,7 +1117,7 @@ class ProcessorsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/processors/{id}/run-status', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/provenance_api.py
+++ b/nipyapi/nifi/apis/provenance_api.py
@@ -43,7 +43,7 @@ class ProvenanceApi(object):
     def delete_lineage(self, id, **kwargs):
         """
         Deletes a lineage query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -70,7 +70,7 @@ class ProvenanceApi(object):
     def delete_lineage_with_http_info(self, id, **kwargs):
         """
         Deletes a lineage query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -133,7 +133,7 @@ class ProvenanceApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance/lineage/{id}', 'DELETE',
                                         path_params,
@@ -153,7 +153,7 @@ class ProvenanceApi(object):
     def delete_provenance(self, id, **kwargs):
         """
         Deletes a provenance query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -180,7 +180,7 @@ class ProvenanceApi(object):
     def delete_provenance_with_http_info(self, id, **kwargs):
         """
         Deletes a provenance query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -243,7 +243,7 @@ class ProvenanceApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance/{id}', 'DELETE',
                                         path_params,
@@ -263,7 +263,7 @@ class ProvenanceApi(object):
     def get_lineage(self, id, **kwargs):
         """
         Gets a lineage query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -290,7 +290,7 @@ class ProvenanceApi(object):
     def get_lineage_with_http_info(self, id, **kwargs):
         """
         Gets a lineage query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -353,7 +353,7 @@ class ProvenanceApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance/lineage/{id}', 'GET',
                                         path_params,
@@ -373,7 +373,7 @@ class ProvenanceApi(object):
     def get_provenance(self, id, **kwargs):
         """
         Gets a provenance query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -402,7 +402,7 @@ class ProvenanceApi(object):
     def get_provenance_with_http_info(self, id, **kwargs):
         """
         Gets a provenance query
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -471,7 +471,7 @@ class ProvenanceApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance/{id}', 'GET',
                                         path_params,
@@ -491,7 +491,7 @@ class ProvenanceApi(object):
     def get_search_options(self, **kwargs):
         """
         Gets the searchable attributes for provenance events
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -516,7 +516,7 @@ class ProvenanceApi(object):
     def get_search_options_with_http_info(self, **kwargs):
         """
         Gets the searchable attributes for provenance events
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -569,7 +569,7 @@ class ProvenanceApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance/search-options', 'GET',
                                         path_params,
@@ -675,7 +675,7 @@ class ProvenanceApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance/lineage', 'POST',
                                         path_params,
@@ -781,7 +781,7 @@ class ProvenanceApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance', 'POST',
                                         path_params,

--- a/nipyapi/nifi/apis/provenance_events_api.py
+++ b/nipyapi/nifi/apis/provenance_events_api.py
@@ -43,7 +43,7 @@ class ProvenanceEventsApi(object):
     def get_input_content(self, id, **kwargs):
         """
         Gets the input content for a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -70,7 +70,7 @@ class ProvenanceEventsApi(object):
     def get_input_content_with_http_info(self, id, **kwargs):
         """
         Gets the input content for a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -133,7 +133,7 @@ class ProvenanceEventsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance-events/{id}/content/input', 'GET',
                                         path_params,
@@ -153,7 +153,7 @@ class ProvenanceEventsApi(object):
     def get_output_content(self, id, **kwargs):
         """
         Gets the output content for a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -180,7 +180,7 @@ class ProvenanceEventsApi(object):
     def get_output_content_with_http_info(self, id, **kwargs):
         """
         Gets the output content for a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -243,7 +243,7 @@ class ProvenanceEventsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance-events/{id}/content/output', 'GET',
                                         path_params,
@@ -263,7 +263,7 @@ class ProvenanceEventsApi(object):
     def get_provenance_event(self, id, **kwargs):
         """
         Gets a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -290,7 +290,7 @@ class ProvenanceEventsApi(object):
     def get_provenance_event_with_http_info(self, id, **kwargs):
         """
         Gets a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -353,7 +353,7 @@ class ProvenanceEventsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance-events/{id}', 'GET',
                                         path_params,
@@ -373,7 +373,7 @@ class ProvenanceEventsApi(object):
     def submit_replay(self, body, **kwargs):
         """
         Replays content from a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -399,7 +399,7 @@ class ProvenanceEventsApi(object):
     def submit_replay_with_http_info(self, body, **kwargs):
         """
         Replays content from a provenance event
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -459,7 +459,7 @@ class ProvenanceEventsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/provenance-events/replays', 'POST',
                                         path_params,

--- a/nipyapi/nifi/apis/remote_process_groups_api.py
+++ b/nipyapi/nifi/apis/remote_process_groups_api.py
@@ -43,7 +43,7 @@ class RemoteProcessGroupsApi(object):
     def get_remote_process_group(self, id, **kwargs):
         """
         Gets a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class RemoteProcessGroupsApi(object):
     def get_remote_process_group_with_http_info(self, id, **kwargs):
         """
         Gets a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}', 'GET',
                                         path_params,
@@ -149,7 +149,7 @@ class RemoteProcessGroupsApi(object):
     def get_state(self, id, **kwargs):
         """
         Gets the state for a RemoteProcessGroup
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -175,7 +175,7 @@ class RemoteProcessGroupsApi(object):
     def get_state_with_http_info(self, id, **kwargs):
         """
         Gets the state for a RemoteProcessGroup
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -235,7 +235,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}/state', 'GET',
                                         path_params,
@@ -255,7 +255,7 @@ class RemoteProcessGroupsApi(object):
     def remove_remote_process_group(self, id, **kwargs):
         """
         Deletes a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -284,7 +284,7 @@ class RemoteProcessGroupsApi(object):
     def remove_remote_process_group_with_http_info(self, id, **kwargs):
         """
         Deletes a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -353,7 +353,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}', 'DELETE',
                                         path_params,
@@ -373,7 +373,7 @@ class RemoteProcessGroupsApi(object):
     def update_remote_process_group(self, id, body, **kwargs):
         """
         Updates a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -400,7 +400,7 @@ class RemoteProcessGroupsApi(object):
     def update_remote_process_group_with_http_info(self, id, body, **kwargs):
         """
         Updates a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -466,7 +466,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}', 'PUT',
                                         path_params,
@@ -586,7 +586,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}/input-ports/{port-id}', 'PUT',
                                         path_params,
@@ -706,7 +706,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}/input-ports/{port-id}/run-status', 'PUT',
                                         path_params,
@@ -826,7 +826,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}/output-ports/{port-id}', 'PUT',
                                         path_params,
@@ -946,7 +946,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}/output-ports/{port-id}/run-status', 'PUT',
                                         path_params,
@@ -966,7 +966,7 @@ class RemoteProcessGroupsApi(object):
     def update_remote_process_group_run_status(self, id, body, **kwargs):
         """
         Updates run status of a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -993,7 +993,7 @@ class RemoteProcessGroupsApi(object):
     def update_remote_process_group_run_status_with_http_info(self, id, body, **kwargs):
         """
         Updates run status of a remote process group
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -1059,7 +1059,7 @@ class RemoteProcessGroupsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/remote-process-groups/{id}/run-status', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/reporting_tasks_api.py
+++ b/nipyapi/nifi/apis/reporting_tasks_api.py
@@ -43,7 +43,7 @@ class ReportingTasksApi(object):
     def clear_state(self, id, **kwargs):
         """
         Clears the state for a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class ReportingTasksApi(object):
     def clear_state_with_http_info(self, id, **kwargs):
         """
         Clears the state for a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}/state/clear-requests', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class ReportingTasksApi(object):
     def get_property_descriptor(self, id, property_name, **kwargs):
         """
         Gets a reporting task property descriptor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -176,7 +176,7 @@ class ReportingTasksApi(object):
     def get_property_descriptor_with_http_info(self, id, property_name, **kwargs):
         """
         Gets a reporting task property descriptor
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -242,7 +242,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}/descriptors', 'GET',
                                         path_params,
@@ -262,7 +262,7 @@ class ReportingTasksApi(object):
     def get_reporting_task(self, id, **kwargs):
         """
         Gets a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -288,7 +288,7 @@ class ReportingTasksApi(object):
     def get_reporting_task_with_http_info(self, id, **kwargs):
         """
         Gets a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -348,7 +348,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}', 'GET',
                                         path_params,
@@ -368,7 +368,7 @@ class ReportingTasksApi(object):
     def get_state(self, id, **kwargs):
         """
         Gets the state for a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -394,7 +394,7 @@ class ReportingTasksApi(object):
     def get_state_with_http_info(self, id, **kwargs):
         """
         Gets the state for a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -454,7 +454,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}/state', 'GET',
                                         path_params,
@@ -474,7 +474,7 @@ class ReportingTasksApi(object):
     def remove_reporting_task(self, id, **kwargs):
         """
         Deletes a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -503,7 +503,7 @@ class ReportingTasksApi(object):
     def remove_reporting_task_with_http_info(self, id, **kwargs):
         """
         Deletes a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -572,7 +572,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}', 'DELETE',
                                         path_params,
@@ -592,7 +592,7 @@ class ReportingTasksApi(object):
     def update_reporting_task(self, id, body, **kwargs):
         """
         Updates a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -619,7 +619,7 @@ class ReportingTasksApi(object):
     def update_reporting_task_with_http_info(self, id, body, **kwargs):
         """
         Updates a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -685,7 +685,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}', 'PUT',
                                         path_params,
@@ -705,7 +705,7 @@ class ReportingTasksApi(object):
     def update_run_status(self, id, body, **kwargs):
         """
         Updates run status of a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -732,7 +732,7 @@ class ReportingTasksApi(object):
     def update_run_status_with_http_info(self, id, body, **kwargs):
         """
         Updates run status of a reporting task
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -798,7 +798,7 @@ class ReportingTasksApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/reporting-tasks/{id}/run-status', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/resources_api.py
+++ b/nipyapi/nifi/apis/resources_api.py
@@ -43,7 +43,7 @@ class ResourcesApi(object):
     def get_resources(self, **kwargs):
         """
         Gets the available resources that support access/authorization policies
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -68,7 +68,7 @@ class ResourcesApi(object):
     def get_resources_with_http_info(self, **kwargs):
         """
         Gets the available resources that support access/authorization policies
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -121,7 +121,7 @@ class ResourcesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/resources', 'GET',
                                         path_params,

--- a/nipyapi/nifi/apis/site_to_site_api.py
+++ b/nipyapi/nifi/apis/site_to_site_api.py
@@ -43,7 +43,7 @@ class SiteToSiteApi(object):
     def get_peers(self, **kwargs):
         """
         Returns the available Peers and its status of this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -68,7 +68,7 @@ class SiteToSiteApi(object):
     def get_peers_with_http_info(self, **kwargs):
         """
         Returns the available Peers and its status of this NiFi
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -121,7 +121,7 @@ class SiteToSiteApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/site-to-site/peers', 'GET',
                                         path_params,
@@ -141,7 +141,7 @@ class SiteToSiteApi(object):
     def get_site_to_site_details(self, **kwargs):
         """
         Returns the details about this NiFi necessary to communicate via site to site
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -166,7 +166,7 @@ class SiteToSiteApi(object):
     def get_site_to_site_details_with_http_info(self, **kwargs):
         """
         Returns the details about this NiFi necessary to communicate via site to site
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -219,7 +219,7 @@ class SiteToSiteApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/site-to-site', 'GET',
                                         path_params,

--- a/nipyapi/nifi/apis/snippets_api.py
+++ b/nipyapi/nifi/apis/snippets_api.py
@@ -43,7 +43,7 @@ class SnippetsApi(object):
     def create_snippet(self, body, **kwargs):
         """
         Creates a snippet. The snippet will be automatically discarded if not used in a subsequent request after 1 minute.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class SnippetsApi(object):
     def create_snippet_with_http_info(self, body, **kwargs):
         """
         Creates a snippet. The snippet will be automatically discarded if not used in a subsequent request after 1 minute.
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class SnippetsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/snippets', 'POST',
                                         path_params,
@@ -149,7 +149,7 @@ class SnippetsApi(object):
     def delete_snippet(self, id, **kwargs):
         """
         Deletes the components in a snippet and discards the snippet
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -176,7 +176,7 @@ class SnippetsApi(object):
     def delete_snippet_with_http_info(self, id, **kwargs):
         """
         Deletes the components in a snippet and discards the snippet
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -239,7 +239,7 @@ class SnippetsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/snippets/{id}', 'DELETE',
                                         path_params,
@@ -259,7 +259,7 @@ class SnippetsApi(object):
     def update_snippet(self, id, body, **kwargs):
         """
         Move's the components in this Snippet into a new Process Group and discards the snippet
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -286,7 +286,7 @@ class SnippetsApi(object):
     def update_snippet_with_http_info(self, id, body, **kwargs):
         """
         Move's the components in this Snippet into a new Process Group and discards the snippet
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -352,7 +352,7 @@ class SnippetsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/snippets/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/system_diagnostics_api.py
+++ b/nipyapi/nifi/apis/system_diagnostics_api.py
@@ -43,7 +43,7 @@ class SystemDiagnosticsApi(object):
     def get_system_diagnostics(self, **kwargs):
         """
         Gets the diagnostics for the system NiFi is running on
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -70,7 +70,7 @@ class SystemDiagnosticsApi(object):
     def get_system_diagnostics_with_http_info(self, **kwargs):
         """
         Gets the diagnostics for the system NiFi is running on
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -130,7 +130,7 @@ class SystemDiagnosticsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/system-diagnostics', 'GET',
                                         path_params,

--- a/nipyapi/nifi/apis/templates_api.py
+++ b/nipyapi/nifi/apis/templates_api.py
@@ -43,7 +43,7 @@ class TemplatesApi(object):
     def export_template(self, id, **kwargs):
         """
         Exports a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -69,7 +69,7 @@ class TemplatesApi(object):
     def export_template_with_http_info(self, id, **kwargs):
         """
         Exports a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -129,7 +129,7 @@ class TemplatesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/templates/{id}/download', 'GET',
                                         path_params,
@@ -149,7 +149,7 @@ class TemplatesApi(object):
     def remove_template(self, id, **kwargs):
         """
         Deletes a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -176,7 +176,7 @@ class TemplatesApi(object):
     def remove_template_with_http_info(self, id, **kwargs):
         """
         Deletes a template
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -239,7 +239,7 @@ class TemplatesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/templates/{id}', 'DELETE',
                                         path_params,

--- a/nipyapi/nifi/apis/tenants_api.py
+++ b/nipyapi/nifi/apis/tenants_api.py
@@ -129,7 +129,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/users', 'POST',
                                         path_params,
@@ -235,7 +235,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/user-groups', 'POST',
                                         path_params,
@@ -341,7 +341,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/users/{id}', 'GET',
                                         path_params,
@@ -447,7 +447,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/user-groups/{id}', 'GET',
                                         path_params,
@@ -545,7 +545,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/user-groups', 'GET',
                                         path_params,
@@ -643,7 +643,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/users', 'GET',
                                         path_params,
@@ -761,7 +761,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/users/{id}', 'DELETE',
                                         path_params,
@@ -879,7 +879,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/user-groups/{id}', 'DELETE',
                                         path_params,
@@ -985,7 +985,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/search-results', 'GET',
                                         path_params,
@@ -1098,7 +1098,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/users/{id}', 'PUT',
                                         path_params,
@@ -1211,7 +1211,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/tenants/user-groups/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/apis/versions_api.py
+++ b/nipyapi/nifi/apis/versions_api.py
@@ -129,7 +129,7 @@ class VersionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/active-requests', 'POST',
                                         path_params,
@@ -239,7 +239,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/revert-requests/{id}', 'DELETE',
                                         path_params,
@@ -349,7 +349,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/update-requests/{id}', 'DELETE',
                                         path_params,
@@ -459,7 +459,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/active-requests/{id}', 'DELETE',
                                         path_params,
@@ -479,7 +479,7 @@ class VersionsApi(object):
     def export_flow_version(self, id, **kwargs):
         """
         Gets the latest version of a Process Group for download
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -505,7 +505,7 @@ class VersionsApi(object):
     def export_flow_version_with_http_info(self, id, **kwargs):
         """
         Gets the latest version of a Process Group for download
-
+        
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
         to be invoked when receiving the response.
@@ -565,7 +565,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/process-groups/{id}/download', 'GET',
                                         path_params,
@@ -671,7 +671,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/revert-requests/{id}', 'GET',
                                         path_params,
@@ -777,7 +777,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/update-requests/{id}', 'GET',
                                         path_params,
@@ -883,7 +883,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/process-groups/{id}', 'GET',
                                         path_params,
@@ -996,7 +996,7 @@ class VersionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/revert-requests/process-groups/{id}', 'POST',
                                         path_params,
@@ -1109,7 +1109,7 @@ class VersionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/update-requests/process-groups/{id}', 'POST',
                                         path_params,
@@ -1222,7 +1222,7 @@ class VersionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/process-groups/{id}', 'POST',
                                         path_params,
@@ -1340,7 +1340,7 @@ class VersionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/process-groups/{id}', 'DELETE',
                                         path_params,
@@ -1453,7 +1453,7 @@ class VersionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/process-groups/{id}', 'PUT',
                                         path_params,
@@ -1566,7 +1566,7 @@ class VersionsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/versions/active-requests/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/nifi/configuration.py
+++ b/nipyapi/nifi/configuration.py
@@ -52,8 +52,7 @@ class Configuration(object):
         self.temp_folder_path = None
 
         # Authentication Settings
-        # Auth types to enable
-        self.enabled_auth = ['tokenAuth', 'basicAuth']
+        self.force_basic_auth = False
         # dict to store API key(s)
         self.api_key = {}
         # dict to store API prefix (e.g. Bearer)
@@ -190,12 +189,10 @@ class Configuration(object):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
-        if identifier in self.enabled_auth:
-            if self.api_key.get(identifier) and self.api_key_prefix.get(identifier):
-                return self.api_key_prefix[identifier] + ' ' + self.api_key[identifier]
-            elif self.api_key.get(identifier):
-                return self.api_key[identifier]
-        return None
+        if self.api_key.get(identifier) and self.api_key_prefix.get(identifier):
+            return self.api_key_prefix[identifier] + ' ' + self.api_key[identifier]
+        elif self.api_key.get(identifier):
+            return self.api_key[identifier]
 
     def get_basic_auth_token(self):
         """
@@ -203,10 +200,8 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
-        if 'basicAuth' in self.enabled_auth:
-            return urllib3.util.make_headers(basic_auth=self.username + ':' + self.password)\
-                               .get('authorization')
-        return None
+        return urllib3.util.make_headers(basic_auth=self.username + ':' + self.password)\
+                           .get('authorization')
 
     def auth_settings(self):
         """

--- a/nipyapi/nifi/models/action_details_dto.py
+++ b/nipyapi/nifi/models/action_details_dto.py
@@ -31,11 +31,11 @@ class ActionDetailsDTO(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-
+        
     }
 
     attribute_map = {
-
+        
     }
 
     def __init__(self):

--- a/nipyapi/nifi/models/component_details_dto.py
+++ b/nipyapi/nifi/models/component_details_dto.py
@@ -31,11 +31,11 @@ class ComponentDetailsDTO(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-
+        
     }
 
     attribute_map = {
-
+        
     }
 
     def __init__(self):

--- a/nipyapi/nifi/models/streaming_output.py
+++ b/nipyapi/nifi/models/streaming_output.py
@@ -31,11 +31,11 @@ class StreamingOutput(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-
+        
     }
 
     attribute_map = {
-
+        
     }
 
     def __init__(self):

--- a/nipyapi/parameters.py
+++ b/nipyapi/parameters.py
@@ -89,14 +89,15 @@ def create_parameter_context(name, description=None, parameters=None):
             component=ParameterContextDTO(
                 name=name,
                 description=description,
-                parameters=parameters if parameters else list()  # list() per NiFi Jira 7995
+                parameters=parameters if parameters else list()
+                # list() per NiFi Jira 7995
             )
         )
     )
     return out
 
 
-def update_parameter_context(context, refresh=True):
+def update_parameter_context(context):
     """
     Update an already existing Parameter Context
 

--- a/nipyapi/registry/api_client.py
+++ b/nipyapi/registry/api_client.py
@@ -194,6 +194,9 @@ class ApiClient(object):
         elif isinstance(obj, list):
             return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
+        elif isinstance(obj, set):
+            return {self.sanitize_for_serialization(sub_obj)
+                    for sub_obj in obj}
         elif isinstance(obj, tuple):
             return tuple(self.sanitize_for_serialization(sub_obj)
                          for sub_obj in obj)
@@ -253,6 +256,9 @@ class ApiClient(object):
         if type(klass) == str:
             if klass.startswith('list['):
                 sub_kls = re.match('list\[(.*)\]', klass).group(1)
+                if isinstance(data, dict):
+                    # ok, we got a single instance when we may have gotten a list
+                    return self.__deserialize(data, sub_kls)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
@@ -517,6 +523,8 @@ class ApiClient(object):
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'
                     )
+        if config.force_basic_auth:
+            headers['Authorization'] = config.get_basic_auth_token()
 
     def __deserialize_file(self, response):
         """
@@ -609,6 +617,16 @@ class ApiClient(object):
                 )
             )
 
+    def deserialize_model(self, data, klass):
+        """
+        Deserializes list or dict to model.
+
+        :param data: dict, list.
+        :param klass: class literal.
+        :return: model object.
+        """
+        return self.__deserialize_model(data, klass)
+
     def __deserialize_model(self, data, klass):
         """
         Deserializes list or dict to model.
@@ -626,8 +644,22 @@ class ApiClient(object):
                and klass.attribute_map[attr] in data \
                and isinstance(data, (list, dict)):
                 value = data[klass.attribute_map[attr]]
-                kwargs[attr] = self.__deserialize(value, attr_type)
+                if attr_type.startswith('list['):
+                    # if this is a list, we may get back a single item
+                    # or a list
+                    # create the list object if it doesn't exist
+                    # append the return
+                    if not kwargs.get(attr):
+                        kwargs[attr] = []
+                    deserialized_value = self.__deserialize(value, attr_type)
+                    if deserialized_value:
+                        if isinstance(deserialized_value, list):
+                            kwargs[attr].extend(deserialized_value)
+                        else:
+                            kwargs[attr].append(deserialized_value)
+                else:
+                    kwargs[attr] = self.__deserialize(value, attr_type)
 
-        instance = klass(**kwargs)     
+        instance = klass(**kwargs)
 
         return instance

--- a/nipyapi/registry/apis/access_api.py
+++ b/nipyapi/registry/apis/access_api.py
@@ -121,7 +121,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/token', 'POST',
                                         path_params,
@@ -219,7 +219,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'BasicAuth']
+        auth_settings = ['tokenAuth', 'BasicAuth']
 
         return self.api_client.call_api('/access/token/login', 'POST',
                                         path_params,
@@ -317,7 +317,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/token/identity-provider', 'POST',
                                         path_params,
@@ -415,7 +415,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/token/kerberos', 'POST',
                                         path_params,
@@ -513,7 +513,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/access', 'GET',
                                         path_params,
@@ -611,7 +611,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/token/identity-provider/usage', 'GET',
                                         path_params,
@@ -709,7 +709,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/logout', 'DELETE',
                                         path_params,
@@ -807,7 +807,7 @@ class AccessApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth']
+        auth_settings = ['tokenAuth']
 
         return self.api_client.call_api('/access/token/identity-provider/test', 'POST',
                                         path_params,

--- a/nipyapi/registry/apis/bucket_bundles_api.py
+++ b/nipyapi/registry/apis/bucket_bundles_api.py
@@ -136,7 +136,7 @@ class BucketBundlesApi(object):
             select_header_content_type(['multipart/form-data'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/bundles/{bundleType}', 'POST',
                                         path_params,
@@ -242,7 +242,7 @@ class BucketBundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/bundles', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/bucket_flows_api.py
+++ b/nipyapi/registry/apis/bucket_flows_api.py
@@ -136,7 +136,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows', 'POST',
                                         path_params,
@@ -256,7 +256,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}/versions', 'POST',
                                         path_params,
@@ -377,7 +377,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}', 'DELETE',
                                         path_params,
@@ -490,7 +490,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}', 'GET',
                                         path_params,
@@ -621,7 +621,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}/diff/{versionA}/{versionB}', 'GET',
                                         path_params,
@@ -743,7 +743,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}/versions/{versionNumber}', 'GET',
                                         path_params,
@@ -856,7 +856,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}/versions', 'GET',
                                         path_params,
@@ -962,7 +962,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows', 'GET',
                                         path_params,
@@ -1075,7 +1075,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}/versions/latest', 'GET',
                                         path_params,
@@ -1188,7 +1188,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}/versions/latest/metadata', 'GET',
                                         path_params,
@@ -1308,7 +1308,7 @@ class BucketFlowsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}/flows/{flowId}', 'PUT',
                                         path_params,

--- a/nipyapi/registry/apis/buckets_api.py
+++ b/nipyapi/registry/apis/buckets_api.py
@@ -129,7 +129,7 @@ class BucketsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets', 'POST',
                                         path_params,
@@ -243,7 +243,7 @@ class BucketsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}', 'DELETE',
                                         path_params,
@@ -341,7 +341,7 @@ class BucketsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/fields', 'GET',
                                         path_params,
@@ -447,7 +447,7 @@ class BucketsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}', 'GET',
                                         path_params,
@@ -545,7 +545,7 @@ class BucketsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets', 'GET',
                                         path_params,
@@ -658,7 +658,7 @@ class BucketsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/buckets/{bucketId}', 'PUT',
                                         path_params,

--- a/nipyapi/registry/apis/bundles_api.py
+++ b/nipyapi/registry/apis/bundles_api.py
@@ -143,7 +143,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}/extensions/{name}/docs/additional-details', 'GET',
                                         path_params,
@@ -263,7 +263,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}/extensions/{name}/docs', 'GET',
                                         path_params,
@@ -374,7 +374,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/versions', 'GET',
                                         path_params,
@@ -485,7 +485,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles', 'GET',
                                         path_params,
@@ -598,7 +598,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}', 'DELETE',
                                         path_params,
@@ -704,7 +704,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}', 'DELETE',
                                         path_params,
@@ -817,7 +817,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}', 'GET',
                                         path_params,
@@ -930,7 +930,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}/content', 'GET',
                                         path_params,
@@ -1050,7 +1050,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}/extensions/{name}', 'GET',
                                         path_params,
@@ -1163,7 +1163,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions/{version}/extensions', 'GET',
                                         path_params,
@@ -1269,7 +1269,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}/versions', 'GET',
                                         path_params,
@@ -1375,7 +1375,7 @@ class BundlesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/bundles/{bundleId}', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/config_api.py
+++ b/nipyapi/registry/apis/config_api.py
@@ -121,7 +121,7 @@ class ConfigApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/config', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/extension_repository_api.py
+++ b/nipyapi/registry/apis/extension_repository_api.py
@@ -136,7 +136,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}', 'GET',
                                         path_params,
@@ -234,7 +234,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository', 'GET',
                                         path_params,
@@ -340,7 +340,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}', 'GET',
                                         path_params,
@@ -467,7 +467,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}', 'GET',
                                         path_params,
@@ -594,7 +594,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}/content', 'GET',
                                         path_params,
@@ -728,7 +728,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}/extensions/{name}', 'GET',
                                         path_params,
@@ -862,7 +862,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}/extensions/{name}/docs/additional-details', 'GET',
                                         path_params,
@@ -996,7 +996,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}/extensions/{name}/docs', 'GET',
                                         path_params,
@@ -1123,7 +1123,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}/extensions', 'GET',
                                         path_params,
@@ -1250,7 +1250,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}/{version}/sha256', 'GET',
                                         path_params,
@@ -1370,7 +1370,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{bucketName}/{groupId}/{artifactId}', 'GET',
                                         path_params,
@@ -1490,7 +1490,7 @@ class ExtensionRepositoryApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extension-repository/{groupId}/{artifactId}/{version}/sha256', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/extensions_api.py
+++ b/nipyapi/registry/apis/extensions_api.py
@@ -135,7 +135,7 @@ class ExtensionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extensions', 'GET',
                                         path_params,
@@ -262,7 +262,7 @@ class ExtensionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extensions/provided-service-api', 'GET',
                                         path_params,
@@ -360,7 +360,7 @@ class ExtensionsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/extensions/tags', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/flows_api.py
+++ b/nipyapi/registry/apis/flows_api.py
@@ -121,7 +121,7 @@ class FlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/flows/fields', 'GET',
                                         path_params,
@@ -227,7 +227,7 @@ class FlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/flows/{flowId}', 'GET',
                                         path_params,
@@ -342,7 +342,7 @@ class FlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/flows/{flowId}/versions/{versionNumber}', 'GET',
                                         path_params,
@@ -448,7 +448,7 @@ class FlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/flows/{flowId}/versions', 'GET',
                                         path_params,
@@ -554,7 +554,7 @@ class FlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/flows/{flowId}/versions/latest', 'GET',
                                         path_params,
@@ -660,7 +660,7 @@ class FlowsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/flows/{flowId}/versions/latest/metadata', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/items_api.py
+++ b/nipyapi/registry/apis/items_api.py
@@ -121,7 +121,7 @@ class ItemsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/items/fields', 'GET',
                                         path_params,
@@ -219,7 +219,7 @@ class ItemsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/items', 'GET',
                                         path_params,
@@ -325,7 +325,7 @@ class ItemsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/items/{bucketId}', 'GET',
                                         path_params,

--- a/nipyapi/registry/apis/policies_api.py
+++ b/nipyapi/registry/apis/policies_api.py
@@ -129,7 +129,7 @@ class PoliciesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies', 'POST',
                                         path_params,
@@ -227,7 +227,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies', 'GET',
                                         path_params,
@@ -333,7 +333,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies/{id}', 'GET',
                                         path_params,
@@ -448,7 +448,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies/{action}/{resource}', 'GET',
                                         path_params,
@@ -546,7 +546,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies/resources', 'GET',
                                         path_params,
@@ -660,7 +660,7 @@ class PoliciesApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies/{id}', 'DELETE',
                                         path_params,
@@ -773,7 +773,7 @@ class PoliciesApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/policies/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/registry/apis/tenants_api.py
+++ b/nipyapi/registry/apis/tenants_api.py
@@ -129,7 +129,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/users', 'POST',
                                         path_params,
@@ -235,7 +235,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/user-groups', 'POST',
                                         path_params,
@@ -341,7 +341,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/users/{id}', 'GET',
                                         path_params,
@@ -447,7 +447,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/user-groups/{id}', 'GET',
                                         path_params,
@@ -545,7 +545,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/user-groups', 'GET',
                                         path_params,
@@ -643,7 +643,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/users', 'GET',
                                         path_params,
@@ -757,7 +757,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/users/{id}', 'DELETE',
                                         path_params,
@@ -871,7 +871,7 @@ class TenantsApi(object):
             select_header_content_type(['*/*'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/user-groups/{id}', 'DELETE',
                                         path_params,
@@ -984,7 +984,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/users/{id}', 'PUT',
                                         path_params,
@@ -1097,7 +1097,7 @@ class TenantsApi(object):
             select_header_content_type(['application/json'])
 
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth', 'Authorization']
+        auth_settings = ['tokenAuth', 'Authorization']
 
         return self.api_client.call_api('/tenants/user-groups/{id}', 'PUT',
                                         path_params,

--- a/nipyapi/registry/configuration.py
+++ b/nipyapi/registry/configuration.py
@@ -52,8 +52,7 @@ class Configuration(object):
         self.temp_folder_path = None
 
         # Authentication Settings
-        # Auth types to enable
-        self.enabled_auth = ['tokenAuth', 'basicAuth']
+        self.force_basic_auth = False
         # dict to store API key(s)
         self.api_key = {}
         # dict to store API prefix (e.g. Bearer)
@@ -190,12 +189,10 @@ class Configuration(object):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
-        if identifier in self.enabled_auth:
-            if self.api_key.get(identifier) and self.api_key_prefix.get(identifier):
-                return self.api_key_prefix[identifier] + ' ' + self.api_key[identifier]
-            elif self.api_key.get(identifier):
-                return self.api_key[identifier]
-        return None
+        if self.api_key.get(identifier) and self.api_key_prefix.get(identifier):
+            return self.api_key_prefix[identifier] + ' ' + self.api_key[identifier]
+        elif self.api_key.get(identifier):
+            return self.api_key[identifier]
 
     def get_basic_auth_token(self):
         """
@@ -203,10 +200,8 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
-        if 'basicAuth' in self.enabled_auth:
-            return urllib3.util.make_headers(basic_auth=self.username + ':' + self.password)\
-                               .get('authorization')
-        return None
+        return urllib3.util.make_headers(basic_auth=self.username + ':' + self.password)\
+                           .get('authorization')
 
     def auth_settings(self):
         """

--- a/nipyapi/utils.py
+++ b/nipyapi/utils.py
@@ -488,8 +488,12 @@ def check_version(base, comparator=None, service='nifi'):
         ver_b = version.parse(comparator)
     elif service == 'registry':
         try:
-            reg_swagger_def = nipyapi.registry.ApiClient().call_api(
-                '/swagger/swagger.json', 'GET', _preload_content=False
+            config = nipyapi.config.registry_config
+            if config.api_client is None:
+                raise ValueError("Not connected to NiFi Registry")
+            reg_swagger_def = config.api_client.call_api(
+                resource_path='/swagger/swagger.json', method='GET', _preload_content=False,
+                auth_settings=['tokenAuth', 'Authorization']
             )
             reg_json = load(reg_swagger_def[0].data)
             ver_b = version.parse(reg_json['info']['version'])

--- a/nipyapi/utils.py
+++ b/nipyapi/utils.py
@@ -490,7 +490,7 @@ def check_version(base, comparator=None, service='nifi'):
         try:
             config = nipyapi.config.registry_config
             if config.api_client is None:
-                raise ValueError("Not connected to NiFi Registry")
+                config = nipyapi.registry.ApiClient()
             reg_swagger_def = config.api_client.call_api(
                 resource_path='/swagger/swagger.json', method='GET', _preload_content=False,
                 auth_settings=['tokenAuth', 'Authorization']

--- a/nipyapi/utils.py
+++ b/nipyapi/utils.py
@@ -37,7 +37,8 @@ log = logging.getLogger(__name__)
 
 def dump(obj, mode='json'):
     """
-    Dumps a native datatype object or swagger entity to json or yaml, defaults to json
+    Dumps a native datatype object or swagger entity to json or yaml
+        defaults to json
 
     Args:
         obj (varies): The native datatype object or swagger type to serialise
@@ -47,14 +48,8 @@ def dump(obj, mode='json'):
 
     """
     assert mode in ['json', 'yaml']
-    unset = False
-    if nipyapi.config.nifi_config.api_client is None:
-        unset = True
-        nipyapi.config.nifi_config.api_client = nipyapi.nifi.ApiClient()
-
-    prepared_obj = nipyapi.config.nifi_config.api_client.sanitize_for_serialization(obj)
-    if unset:
-        nipyapi.config.nifi_config.api_client = None
+    api_client = nipyapi.nifi.ApiClient()
+    prepared_obj = api_client.sanitize_for_serialization(obj)
     try:
         out = json.dumps(
             obj=prepared_obj,
@@ -466,8 +461,8 @@ def strip_snapshot(java_version):
 
 def check_version(base, comparator=None, service='nifi'):
     """
-    Compares version base against either version comparator, or the version of the
-    currently connected service instance.
+    Compares version base against either version comparator, or the version
+    of the currently connected service instance.
 
     Since NiFi is java, it may return a version with -SNAPSHOT as part of it.
     As such, that will be stripped from either the comparator version or
@@ -479,7 +474,7 @@ def check_version(base, comparator=None, service='nifi'):
         service (str): The service to test the version against, currently
             only supports NiFi
 
-    Returns (int): -1 if base is lower, 0 if equal, and 1 if newer than comparator
+    Returns (int): -1/0/1 if base is lower/equal/newer than comparator
 
     """
     assert isinstance(base, six.string_types)
@@ -494,20 +489,24 @@ def check_version(base, comparator=None, service='nifi'):
     elif service == 'registry':
         try:
             reg_swagger_def = nipyapi.registry.ApiClient().call_api(
-                '/swagger/swagger.json', 'GET', _preload_content=False,
-                auth_settings=nipyapi.config.registry_config.enabled_auth
+                '/swagger/swagger.json', 'GET', _preload_content=False
             )
             reg_json = load(reg_swagger_def[0].data)
             ver_b = version.parse(reg_json['info']['version'])
         except nipyapi.registry.rest.ApiException as e:
             if e.status == 404:
-                log.warning("Unable to retrieve swagger.json from registry to check version, assuming older than 0.3")
+                log.warning("Unable to retrieve swagger.json from registry "
+                            "to check version, assuming older than 0.3")
                 ver_b = version.parse('0.2.0')
             else:
                 raise
     else:
         # Working with NiFi
-        ver_b = version.parse(strip_snapshot(nipyapi.system.get_nifi_version_info().ni_fi_version))
+        ver_b = version.parse(
+            strip_snapshot(
+                nipyapi.system.get_nifi_version_info().ni_fi_version
+            )
+        )
     if ver_b > ver_a:
         return -1
     if ver_b < ver_a:
@@ -516,8 +515,13 @@ def check_version(base, comparator=None, service='nifi'):
 
 
 def validate_parameters_versioning_support():
-    if enforce_min_ver('1.10', bool_response=True) or enforce_min_ver('0.6', service='registry', bool_response=True):
-        log.warning("Connected NiFi Registry does not support Parameter Contexts and they will be lost in "
+    """Convenience method to check if Parameters are supported"""
+    nifi_check = enforce_min_ver('1.10', bool_response=True)
+    registry_check = enforce_min_ver(
+        '0.6', service='registry', bool_response=True)
+    if nifi_check or registry_check:
+        log.warning("Connected NiFi Registry does not support "
+                    "Parameter Contexts and they will be lost in "
                     "Version Control".format())
 
 

--- a/nipyapi/utils.py
+++ b/nipyapi/utils.py
@@ -490,7 +490,7 @@ def check_version(base, comparator=None, service='nifi'):
         try:
             config = nipyapi.config.registry_config
             if config.api_client is None:
-                config = nipyapi.registry.ApiClient()
+                config.api_client = nipyapi.registry.ApiClient()
             reg_swagger_def = config.api_client.call_api(
                 resource_path='/swagger/swagger.json', method='GET', _preload_content=False,
                 auth_settings=['tokenAuth', 'Authorization']

--- a/nipyapi/versioning.py
+++ b/nipyapi/versioning.py
@@ -241,13 +241,13 @@ def save_flow_ver(process_group, registry_client, bucket, flow_name=None,
     else:
         target_pg = process_group
     flow_dto = nipyapi.nifi.VersionedFlowDTO(
-                bucket_id=bucket.identifier,
-                comments=comment,
-                description=desc,
-                flow_name=flow_name,
-                flow_id=flow_id,
-                registry_id=registry_client.id
-            )
+        bucket_id=bucket.identifier,
+        comments=comment,
+        description=desc,
+        flow_name=flow_name,
+        flow_id=flow_id,
+        registry_id=registry_client.id
+    )
     if nipyapi.utils.check_version('1.10.0') <= 0:
         # no 'action' property in versions < 1.10
         flow_dto.action = 'FORCE_COMMIT' if force else 'COMMIT'
@@ -513,6 +513,7 @@ def create_flow_version(flow, flow_snapshot, refresh=True):
             for p in bad_params:
                 obj.__setattr__(p, None)
         nipyapi.utils.validate_parameters_versioning_support()
+        ecs = flow_snapshot.external_controller_services
         return nipyapi.registry.BucketFlowsApi().create_flow_version(
             bucket_id=target_bucket.identifier,
             flow_id=target_flow.identifier,
@@ -521,7 +522,7 @@ def create_flow_version(flow, flow_snapshot, refresh=True):
                 bucket=target_bucket,
                 flow_contents=flow_snapshot.flow_contents,
                 parameter_contexts=flow_snapshot.parameter_contexts,
-                external_controller_services=flow_snapshot.external_controller_services,
+                external_controller_services=ecs,
                 snapshot_metadata=VfsMd(
                     version=target_flow.version_count + 1,
                     comments=flow_snapshot.snapshot_metadata.comments,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ pip>=9.0.1
 
 # Project management and Deployment
 bumpversion>=0.5.3
-watchdog>=0.8.3,<1.0.0
+watchdog>=0.8.3,<1.0.0  # pyup: ignore
 twine>=1.9.1,<2.0.0  # pyup: ignore
 virtualenvwrapper>=4.8
 virtualenv>=16.0.0  # required for tox 3.14.2 but not forced

--- a/resources/client_gen/swagger_templates/api.mustache
+++ b/resources/client_gen/swagger_templates/api.mustache
@@ -208,7 +208,7 @@ class {{classname}}(object):
 
         {{/hasConsumes}}
         # Authentication setting
-        auth_settings = ['tokenAuth', 'basicAuth'{{#authMethods}}, '{{name}}'{{/authMethods}}]
+        auth_settings = ['tokenAuth'{{#authMethods}}, '{{name}}'{{/authMethods}}]
 
         return self.api_client.call_api('{{{path}}}', '{{httpMethod}}',
                                         path_params,

--- a/resources/client_gen/swagger_templates/api_client.mustache
+++ b/resources/client_gen/swagger_templates/api_client.mustache
@@ -514,6 +514,8 @@ class ApiClient(object):
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'
                     )
+        if config.force_basic_auth:
+            headers['Authorization'] = config.get_basic_auth_token()
 
     def __deserialize_file(self, response):
         """

--- a/resources/client_gen/swagger_templates/configuration.mustache
+++ b/resources/client_gen/swagger_templates/configuration.mustache
@@ -43,8 +43,7 @@ class Configuration(object):
         self.temp_folder_path = None
 
         # Authentication Settings
-        # Auth types to enable
-        self.enabled_auth = ['tokenAuth', 'basicAuth']
+        self.force_basic_auth = False
         # dict to store API key(s)
         self.api_key = {}
         # dict to store API prefix (e.g. Bearer)
@@ -184,12 +183,10 @@ class Configuration(object):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
-        if identifier in self.enabled_auth:
-            if self.api_key.get(identifier) and self.api_key_prefix.get(identifier):
-                return self.api_key_prefix[identifier] + ' ' + self.api_key[identifier]
-            elif self.api_key.get(identifier):
-                return self.api_key[identifier]
-        return None
+        if self.api_key.get(identifier) and self.api_key_prefix.get(identifier):
+            return self.api_key_prefix[identifier] + ' ' + self.api_key[identifier]
+        elif self.api_key.get(identifier):
+            return self.api_key[identifier]
 
     def get_basic_auth_token(self):
         """
@@ -197,10 +194,8 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
-        if 'basicAuth' in self.enabled_auth:
-            return urllib3.util.make_headers(basic_auth=self.username + ':' + self.password)\
-                               .get('authorization')
-        return None
+        return urllib3.util.make_headers(basic_auth=self.username + ':' + self.password)\
+                           .get('authorization')
 
     def auth_settings(self):
         """


### PR DESCRIPTION
[nipyapi-0.16.1-py2.py3-none-any.whl.zip](https://github.com/Chaffelson/nipyapi/files/5837325/nipyapi-0.16.1-py2.py3-none-any.whl.zip)

Revert 0.14.3 changes to Authentication handling which introduced basicAuth support but resulted in some NiFi connections appearing incorrectly as Anonymous
Added simpler basicAuth control to force it via a config switch without changing tokenAuth and other Authorization header behavior during normal usage
nipyapi.config.global_force_basic_auth is now available for use for this purpose
Moved all Security controls in config.py to a common area at the foot of the file
Removed auth_type from security.service_login as it is now redundant
Added controls to handle certificate checking behavior which has become more strict in recently versions of Python3, ssl_verify and check_hostname are now handled
security.set_service_auth_token now has an explicit flag for ssl host checking as well
Fix oversight where improved model serialisation logic was not correctly applied to Registry
Removed unusused parameter refresh from parameters.update_parameter_context
Reduced unecessary complexity in utils.dump with no change in functionality
Updated client gen mustache templates to reflect refactored security and api client code
Minor linting and docstring and codestyle improvements