### PR TITLE
 Added gzip as default request header

### DIFF
--- a/nipyapi/nifi/api_client.py
+++ b/nipyapi/nifi/api_client.py
@@ -65,6 +65,7 @@ class ApiClient(object):
         """
         self.rest_client = RESTClientObject()
         self.default_headers = {}
+        self.default_headers["Accept-Encoding"] = 'gzip, deflate'
         if header_name is not None:
             self.default_headers[header_name] = header_value
         if host is None:


### PR DESCRIPTION
Fixes #273 by adding gzip headers to the api client.

Tested on a small dev cluster, nipyapi 0.16.2 and NiFi 1.11. 
It seems like there were additional improvements on NiFi/nipyapi that reduced the impact of this patch, this is still necessary on larger clusters and while making complex automations.

Before:
```
In []: %%time
   ...: import nipyapi
   ...: a=nipyapi.canvas.list_all_processors()
   ...:
   ...:
CPU times: user 22.3 s, sys: 3.46 s, total: 25.8 s
Wall time: 1min 27s

In []: %%time
   ...: import nipyapi
   ...: a=nipyapi.canvas.list_all_controllers()
   ...:
   ...:
CPU times: user 12.1 s, sys: 2.24 s, total: 14.3 s
Wall time: 35.7 s
```
After:
```
In []: %%time
   ...: import nipyapi
   ...: a=nipyapi.canvas.list_all_processors()
   ...:
   ...:
CPU times: user 19.8 s, sys: 1.11 s, total: 20.9 s
Wall time: 1min 1s

In []: %%time
   ...: import nipyapi
   ...: a=nipyapi.canvas.list_all_controllers()
   ...:
   ...:
CPU times: user 11.4 s, sys: 481 ms, total: 11.9 s
Wall time: 19.6 s
```

