### PR TITLE
Added link to doc index for parameter contexts

### DIFF
--- a/docs/nipyapi-docs/nipyapi.rst
+++ b/docs/nipyapi-docs/nipyapi.rst
@@ -30,6 +30,14 @@ Config
     :undoc-members:
     :show-inheritance:
 
+Parameters
+----------
+
+.. automodule:: nipyapi.parameters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Security
 --------
 


### PR DESCRIPTION
NiFi parameter contexts are implemented so it makes sense to include this in the docs.