### PR TITLE
Fix parameterSensitivities by removing unsupported enum

### DIFF
--- a/nipyapi/nifi/models/parameter_group_configuration_entity.py
+++ b/nipyapi/nifi/models/parameter_group_configuration_entity.py
@@ -130,10 +130,10 @@ class ParameterGroupConfigurationEntity(object):
         :type: dict(str, str)
         """
         allowed_values = ["SENSITIVE", "NON_SENSITIVE"]
-        if not set(parameter_sensitivities.keys()).issubset(set(allowed_values)):
+        if not set(parameter_sensitivities.values()).issubset(set(allowed_values)):
             raise ValueError(
-                "Invalid keys in `parameter_sensitivities` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set(parameter_sensitivities.keys())-set(allowed_values))),
+                "Invalid values in `parameter_sensitivities` [{0}], must be a subset of [{1}]"
+                .format(", ".join(map(str, set(parameter_sensitivities.values())-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 

--- a/resources/client_gen/swagger_templates/model.mustache
+++ b/resources/client_gen/swagger_templates/model.mustache
@@ -101,10 +101,10 @@ class {{classname}}(object):
             )
 {{/isListContainer}}
 {{#isMapContainer}}
-        if not set({{{name}}}.keys()).issubset(set(allowed_values)):
+        if not set({{{name}}}.values()).issubset(set(allowed_values)):
             raise ValueError(
-                "Invalid keys in `{{{name}}}` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set({{{name}}}.keys())-set(allowed_values))),
+                "Invalid values in `{{{name}}}` [{0}], must be a subset of [{1}]"
+                .format(", ".join(map(str, set({{{name}}}.values())-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 {{/isMapContainer}}


### PR DESCRIPTION
This PR fixes creation of ParameterContexts. There are a few issues with the current implementation:

* The swagger-codegen package adds a validation on the keys instead of the values. See https://github.com/swagger-api/swagger-codegen/issues/9138. I've worked around this issue by removing the enum.
* Also, NiFi replies with the sensitivity set to `null`. This prevented the reply from being parsed correctly.

~~Also, I noticed the following issues when trying to fix this:~~
* ~~`generate_api_client.sh` uses a invalid domain to fetch swagger-codegen-cli, it's also using an old version.~~
* ~~The `self.logger["package_logger"] = logging.getLogger("swagger_client")` line was incorrectly updated in the past PR. Running the codegen sets it to `logging.getLogger("nifi")` as it was before the last change.~~

I'll move these changes to a different PR.

Fixes #325