### PR TITLE
Fix API model generator

### DIFF
--- a/resources/client_gen/generate_api_client.sh
+++ b/resources/client_gen/generate_api_client.sh
@@ -10,13 +10,13 @@
 echo Exporting Params
 export wv_client_name=${wv_client_name:-nifi}
 
-export wv_codegen_filename=${wv_codegen_filename:-swagger-codegen-cli-2.3.1.jar}
+export wv_codegen_filename=${wv_codegen_filename:-swagger-codegen-cli-2.4.41.jar}
 export wv_tmp_dir=${wv_tmp_dir:-${HOME}/Projects/tmp}
 export wv_client_dir=${wv_tmp_dir}/${wv_client_name}
 export wv_mustache_dir=./swagger_templates
 export wv_api_def_dir=./api_defs
 
-export wv_codegen_url=central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/${wv_codegen_filename}
+export wv_codegen_url=https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.41/${wv_codegen_filename}
 export wv_swagger_def=$(ls ${wv_api_def_dir} | grep ${wv_client_name} | sort -V | tail -1)
 
 echo Prepping Workspace


### PR DESCRIPTION
* generate_api_client.sh uses a invalid domain to fetch swagger-codegen-cli, it's also using an old version.

Moved fix for code generator from #353 to a new PR.