### PR TITLE
Fix parameter_sensitivities checking the values instead of the keys

### DIFF
--- a/nipyapi/nifi/models/parameter_group_configuration_entity.py
+++ b/nipyapi/nifi/models/parameter_group_configuration_entity.py
@@ -129,7 +129,8 @@ class ParameterGroupConfigurationEntity(object):
         :param parameter_sensitivities: The parameter_sensitivities of this ParameterGroupConfigurationEntity.
         :type: dict(str, str)
         """
-        allowed_values = ["SENSITIVE", "NON_SENSITIVE"]
+        # Added None, since that's what NiFi returns when the value is not yet set
+        allowed_values = ["SENSITIVE", "NON_SENSITIVE", None]
         if not set(parameter_sensitivities.values()).issubset(set(allowed_values)):
             raise ValueError(
                 "Invalid values in `parameter_sensitivities` [{0}], must be a subset of [{1}]"

--- a/nipyapi/nifi/models/parameter_group_configuration_entity.py
+++ b/nipyapi/nifi/models/parameter_group_configuration_entity.py
@@ -130,10 +130,10 @@ class ParameterGroupConfigurationEntity(object):
         :type: dict(str, str)
         """
         allowed_values = ["SENSITIVE", "NON_SENSITIVE"]
-        if not set(parameter_sensitivities.keys()).issubset(set(allowed_values)):
+        if not set(parameter_sensitivities.values()).issubset(set(allowed_values)):
             raise ValueError(
-                "Invalid keys in `parameter_sensitivities` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set(parameter_sensitivities.keys())-set(allowed_values))),
+                "Invalid values in `parameter_sensitivities` [{0}], must be a subset of [{1}]"
+                .format(", ".join(map(str, set(parameter_sensitivities.values())-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 

--- a/resources/client_gen/swagger_templates/model.mustache
+++ b/resources/client_gen/swagger_templates/model.mustache
@@ -101,10 +101,10 @@ class {{classname}}(object):
             )
 {{/isListContainer}}
 {{#isMapContainer}}
-        if not set({{{name}}}.keys()).issubset(set(allowed_values)):
+        if not set({{{name}}}.values()).issubset(set(allowed_values)):
             raise ValueError(
-                "Invalid keys in `{{{name}}}` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set({{{name}}}.keys())-set(allowed_values))),
+                "Invalid values in `{{{name}}}` [{0}], must be a subset of [{1}]"
+                .format(", ".join(map(str, set({{{name}}}.values())-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 {{/isMapContainer}}


### PR DESCRIPTION
This PR fixes creation of ParameterContexts.

The swagger-codegen package adds a validation on the keys instead of the values. See https://github.com/swagger-api/swagger-codegen/issues/9138.

Luckily, the default templates from the `swagger-codegen` package are overridden in this repo, so we can make the change here. Looking at the age of the issue, it doesn't seem they are interested in changing their default templates.