### PR TITLE
Handle plain text response types so json values are correctly returned

### DIFF
--- a/nipyapi/nifi/api_client.py
+++ b/nipyapi/nifi/api_client.py
@@ -235,6 +235,10 @@ class ApiClient(object):
         if response_type == "file":
             return self.__deserialize_file(response)
 
+        # handle plain text response
+        if response_type == "str":
+            return response.data
+
         # fetch data from response object
         try:
             data = json.loads(response.data)

--- a/resources/client_gen/swagger_templates/api_client.mustache
+++ b/resources/client_gen/swagger_templates/api_client.mustache
@@ -226,6 +226,10 @@ class ApiClient(object):
         if response_type == "file":
             return self.__deserialize_file(response)
 
+        # handle plain text response
+        if response_type == "str":
+            return response.data
+
         # fetch data from response object
         try:
             data = json.loads(response.data)


### PR DESCRIPTION
This change adds support for returning the actual string as it is returned by NiFi when the return type is set to `str`.

This fixes the `exportTemplate`, `exportFlowVersion` and `exportProcessGroup` API's and probably some others.

The current implementation would `json.loads()` the reply to a `dict`, and then convert that dict to a `str` by using `str()`. This doesn't generate a valid JSON however, since it will be the Python representation of a dict.

Actual returned JSON:
```
{"flowContents":{"identifier":"a9a4cae3-72e5-33c8-b6be-7879e79e5ded","instanceIdentifier":"2f968272-0190-1000-9f4a-82702...
```

Returned JSON after (wrongful) deserialisation:
```
{'flowContents': {'identifier': 'a9a4cae3-72e5-33c8-b6be-7879e79e5ded', 'instance...
```

Fixes #354