### PR TITLE
Update NiPyAPI to be roughly forward compatible with NiFi-2.x line.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,11 @@ NiFi Version Support
 --------------------
 
 | Currently we are testing against NiFi versions 1.9.2 - 1.27.0, and NiFi-Registry versions 0.3.0 - 1.27.0.
-| We have also tested against the latest 2.0.0-M4 release candidates using the 1.x SDK and have found that most things work as expected.
-| In future we will look at creating NiFi 2.x native SDKs, but for now the latest NiPyAPI release should be used with the NiFi 2.0.0-Mx releases.
+
+| We have also tested against the latest 2.0.0-M4 release candidates using the 1.x SDK and have found that basic functionality works as expected.
+| Apache NiFi offers no compatibility guarantees between major versions, and while many functions may work the same, you should test carefully for your specific use case.
+| In future we will create a specific branch of NiPyAPI for NiFi 2.x SDKs, and maintain separate NiFi 1.x and NiFi 2.x clients.
+
 | If you find a version compatibility problem please raise an `issue <https://github.com/Chaffelson/nipyapi/issues>`_
 
 Python Support

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,9 @@ Background and Documentation
 NiFi Version Support
 --------------------
 
-| Currently we are testing against NiFi versions 1.1.2 - 1.27.0, and NiFi-Registry versions 0.1.0 - 1.27.0.
+| Currently we are testing against NiFi versions 1.9.2 - 1.27.0, and NiFi-Registry versions 0.3.0 - 1.27.0.
+| We have also tested against the latest 2.0.0-M4 release candidates using the 1.x SDK and have found that most things work as expected.
+| In future we will look at creating NiFi 2.x native SDKs, but for now the latest NiPyAPI release should be used with the NiFi 2.0.0-Mx releases.
 | If you find a version compatibility problem please raise an `issue <https://github.com/Chaffelson/nipyapi/issues>`_
 
 Python Support

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -402,10 +402,11 @@ def delete_process_group(process_group, force=False, refresh=True):
                         delete_controller(x, True)
                         removed_controllers_id.append(x.component.id)
 
-            # Remove templates
-            for template in nipyapi.templates.list_all_templates(native=False):
-                if target.id == template.template.group_id:
-                    nipyapi.templates.delete_template(template.id)
+            # Templates are not supported in NiFi 2.x
+            if nipyapi.utils.check_version('2', service='nifi') < 0:
+                for template in nipyapi.templates.list_all_templates(native=False):
+                    if target.id == template.template.group_id:
+                        nipyapi.templates.delete_template(template.id)
             # have to refresh revision after changes
             target = nipyapi.nifi.ProcessGroupsApi().get_process_group(pg_id)
             return nipyapi.nifi.ProcessGroupsApi().remove_process_group(

--- a/nipyapi/system.py
+++ b/nipyapi/system.py
@@ -58,3 +58,13 @@ def get_nifi_version_info():
     """
     diags = get_system_diagnostics()
     return diags.system_diagnostics.aggregate_snapshot.version_info
+
+
+def get_registry_version_info():
+    """
+    Returns the version information of the connected NiFi Registry instance
+
+    Returns (VersionInfoDTO):
+    """
+    details = nipyapi.registry.AboutApi().get_version()
+    return details.registry_about_version

--- a/nipyapi/versioning.py
+++ b/nipyapi/versioning.py
@@ -27,7 +27,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-def create_registry_client(name, uri, description):
+def create_registry_client(name, uri, description, reg_type=None):
     """
     Creates a Registry Client in the NiFi Controller Services
 
@@ -42,14 +42,28 @@ def create_registry_client(name, uri, description):
     assert isinstance(uri, six.string_types) and uri is not False
     assert isinstance(name, six.string_types) and name is not False
     assert isinstance(description, six.string_types)
+    if nipyapi.utils.check_version('2', service='nifi') > 0:
+        component = {
+            'uri': uri,
+            'name': name,
+            'description': description
+        }
+    else:
+        component = {
+            'name': name,
+            'description': description,
+            'type': (
+                reg_type or
+                'org.apache.nifi.registry.flow.NifiRegistryFlowRegistryClient'),
+            'properties': {
+                'url': uri
+            }
+        }
+
     with nipyapi.utils.rest_exceptions():
         return nipyapi.nifi.ControllerApi().create_flow_registry_client(
             body={
-                'component': {
-                    'uri': uri,
-                    'name': name,
-                    'description': description
-                },
+                'component': component,
                 'revision': {
                     'version': 0
                 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ tox>=3.28.0
 flake8>=3.6.0
 coverage>=4.4.1
 coveralls>=1.2.0
-pytest  # handled in setup.py
+pytest  # pyup: ignore
 nose>=1.3.7
 pluggy>=0.3.1
 pylint>=1.7.4

--- a/resources/docker/latest/docker-compose.yml
+++ b/resources/docker/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nifi:
-    image: apache/nifi:2.0.0-M4
+    image: apache/nifi:latest
     container_name: nifi
     hostname: nifi
     ports:
@@ -9,7 +9,7 @@ services:
       - SINGLE_USER_CREDENTIALS_USERNAME=nobel
       - SINGLE_USER_CREDENTIALS_PASSWORD=supersecret1!
   registry:
-    image: apache/nifi-registry:2.0.0-M4
+    image: apache/nifi-registry:latest
     container_name: registry
     hostname: registry
     ports:

--- a/resources/docker/latest/docker-compose.yml
+++ b/resources/docker/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nifi:
-    image: apache/nifi:1.27.0
+    image: apache/nifi:2.0.0-M4
     container_name: nifi
     hostname: nifi
     ports:
@@ -9,7 +9,7 @@ services:
       - SINGLE_USER_CREDENTIALS_USERNAME=nobel
       - SINGLE_USER_CREDENTIALS_PASSWORD=supersecret1!
   registry:
-    image: apache/nifi-registry:1.27.0
+    image: apache/nifi-registry:2.0.0-M4
     container_name: registry
     hostname: registry
     ports:

--- a/resources/docker/secure/docker-compose.yml
+++ b/resources/docker/secure/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   secure-nifi:
-    image: apache/nifi:1.27.0
+    image: apache/nifi:2.0.0-M4
     container_name: secure-nifi
     hostname: secure-nifi
     ports:
@@ -25,7 +25,7 @@ services:
       - LDAP_URL=ldap://ldap.forumsys.com:389
       - NIFI_WEB_PROXY_HOST=localhost:9443,localhost:8443
   secure-registry:
-    image: apache/nifi-registry:1.27.0
+    image: apache/nifi-registry:2.0.0-M4
     container_name: secure-registry
     hostname: secure-registry
     ports:

--- a/resources/docker/secure/docker-compose.yml
+++ b/resources/docker/secure/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   secure-nifi:
-    image: apache/nifi:2.0.0-M4
+    image: apache/nifi:latest
     container_name: secure-nifi
     hostname: secure-nifi
     ports:
@@ -25,7 +25,7 @@ services:
       - LDAP_URL=ldap://ldap.forumsys.com:389
       - NIFI_WEB_PROXY_HOST=localhost:9443,localhost:8443
   secure-registry:
-    image: apache/nifi-registry:2.0.0-M4
+    image: apache/nifi-registry:latest
     container_name: secure-registry
     hostname: secure-registry
     ports:

--- a/resources/docker/tox-full/docker-compose.yml
+++ b/resources/docker/tox-full/docker-compose.yml
@@ -1,30 +1,22 @@
 services:
-  nifi-112:
-    image: chaffelson/nifi:1.1.2
-    container_name: nifi-112
-    hostname: nifi-112
-    ports:
-      - "10112:8080"
-  nifi-120:
-    image: apache/nifi:1.2.0
-    container_name: nifi-120
-    hostname: nifi-120
-    ports:
-      - "10120:8080"
-  nifi-180:
-    image: apache/nifi:1.8.0
-    container_name: nifi-180
-    hostname: nifi-180
-    ports:
-      - "10180:8080"
   nifi-192:
     image: apache/nifi:1.9.2
     container_name: nifi-192
     hostname: nifi-192
     ports:
       - "10192:8080"
-  nifi:
+  nifi-127:
     image: apache/nifi:1.27.0
+    container_name: nifi-127
+    hostname: nifi-127
+    ports:
+      - "10127:10127"
+    environment:
+      - SINGLE_USER_CREDENTIALS_USERNAME=nobel
+      - SINGLE_USER_CREDENTIALS_PASSWORD=supersecret1!
+      - NIFI_WEB_HTTPS_PORT=10127
+  nifi:
+    image: apache/nifi:2.0.0-M4
     container_name: nifi
     hostname: nifi
     ports:
@@ -32,14 +24,6 @@ services:
     environment:
       - SINGLE_USER_CREDENTIALS_USERNAME=nobel
       - SINGLE_USER_CREDENTIALS_PASSWORD=supersecret1!
-  registry-010:
-    image: apache/nifi-registry:0.1.0
-    container_name: registry-010
-    hostname: registry-010
-    ports:
-      - "18010:18010"
-    environment:
-      - NIFI_REGISTRY_WEB_HTTP_PORT=18010
   registry-030:
     image: apache/nifi-registry:0.3.0
     container_name: registry-030
@@ -48,6 +32,14 @@ services:
       - "18030:18030"
     environment:
       - NIFI_REGISTRY_WEB_HTTP_PORT=18030
+  registry-127:
+    image: apache/nifi-registry:1.27.0
+    container_name: registry-127
+    hostname: registry-127
+    ports:
+      - "18127:18127"
+    environment:
+      - NIFI_REGISTRY_WEB_HTTP_PORT=18127
   registry:
     image: apache/nifi-registry:1.27.0
     container_name: registry

--- a/resources/docker/tox-full/docker-compose.yml
+++ b/resources/docker/tox-full/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     environment:
       - NIFI_REGISTRY_WEB_HTTP_PORT=18127
   registry:
-    image: apache/nifi-registry:1.27.0
+    image: apache/nifi-registry:2.0.0-M4
     container_name: registry
     hostname: registry
     ports:

--- a/resources/docker/tox-full/readme.md
+++ b/resources/docker/tox-full/readme.md
@@ -14,12 +14,6 @@ Stop a cluster:
 
 - ```docker-compose stop```
 
-## Environment Details
-
-- Apache NiFi 1.2.0 available on port 10120
-- Apache NiFi 1.4.0 available on port 10140
-- Apache NiFi 1.5.0 available on port 8080
-- Apache NiFi-Registry 0.1.0 available on port 18080
 
 ### Notes
-Where possible the latest version will be available on the defaul port, with older versions on identifiable ports for back testing
+Where possible the latest version will be available on the default port, with older versions on identifiable ports for back testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,8 @@ test_templates = {
 
 default_nifi_endpoints = [('https://' + test_host + ':8443/nifi-api', True, True, 'nobel', 'supersecret1!')]
 regress_nifi_endpoints = [
-    ('http://' + test_host + ':10112/nifi-api', True, True, None, None),
-    ('http://' + test_host + ':10120/nifi-api', True, True, None, None),
-    ('http://' + test_host + ':10180/nifi-api', True, True, None, None),
     ('http://' + test_host + ':10192/nifi-api', True, True, None, None),
+    ('https://' + test_host + ':10127/nifi-api', True, True, 'nobel', 'supersecret1!'),
 ]
 secure_nifi_endpoints = [('https://' + test_host + ':9443/nifi-api', True, True, 'nobel', 'password')]
 default_registry_endpoints = [
@@ -69,13 +67,13 @@ default_registry_endpoints = [
      )
 ]
 regress_registry_endpoints = [
-            (('http://' + test_host + ':18010/nifi-registry-api', True, True, None, None),
-                'http://registry-010:18010',
-             ('https://' + test_host + ':8443/nifi-api', True, True, 'nobel', 'supersecret1!')
-             ),
             (('http://' + test_host + ':18030/nifi-registry-api', True, True, None, None),
                 'http://registry-030:18030',
              ('http://' + test_host + ':10192/nifi-api', True, True, None, None)
+             ),
+            (('http://' + test_host + ':18127/nifi-registry-api', True, True, None, None),
+                'http://registry-127:18127',
+             ('https://' + test_host + ':10127/nifi-api', True, True, 'nobel', 'supersecret1!')
              )
         ]
 secure_registry_endpoints = [
@@ -334,7 +332,9 @@ def cleanup_nifi():
     # per test, so we rely on individual fixture cleanup
     log.info("Bulk cleanup called on host %s",
              nipyapi.config.nifi_config.host)
-    remove_test_templates()
+    # Check if NiFi version is 2 or newer
+    if nipyapi.utils.check_version('2', service='nifi') < 0:
+        remove_test_templates()
     remove_test_pgs()
     remove_test_connections()
     remove_test_controllers()

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -178,8 +178,8 @@ def test_list_all_processor_types(regress_nifi):
 
 
 def test_get_processor_type(regress_nifi):
-    r1 = canvas.get_processor_type('GetTwitter')
-    assert r1.type == 'org.apache.nifi.processors.twitter.GetTwitter'
+    r1 = canvas.get_processor_type('GenerateFlowFile')
+    assert r1.type == 'org.apache.nifi.processors.standard.GenerateFlowFile'
     assert isinstance(r1, DocumentedTypeDTO)
     r2 = canvas.get_processor_type("syslog", 'tag')
     assert isinstance(r2, list)
@@ -301,6 +301,8 @@ def test_update_processor(regress_nifi, fix_proc):
 
 
 def test_get_variable_registry(fix_pg):
+    if utils.check_version('2', service='nifi') <= 0:
+        pytest.skip("Not supported in NiFi 2.x")
     test_pg = fix_pg.generate()
     r1 = canvas.get_variable_registry(test_pg)
     assert isinstance(r1, nifi.VariableRegistryEntity)
@@ -310,6 +312,8 @@ def test_get_variable_registry(fix_pg):
 
 
 def test_update_variable_registry(fix_pg):
+    if utils.check_version('2', service='nifi') <= 0:
+        pytest.skip("Not supported in NiFi 2.x")
     test_pg = fix_pg.generate()
     r1 = canvas.update_variable_registry(
         test_pg,

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -15,6 +15,11 @@ if six.PY3:
 elif six.PY2:
     pass
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_if_nifi_version_2():
+    if nipyapi.utils.check_version('2', service='nifi') >= 0:
+        pytest.skip("Skipping tests for NiFi version 2 and above")
+
 
 def test_upload_template(regress_nifi, fix_templates):
     pg = fix_templates.pg.generate()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,7 +149,7 @@ def test_check_version(regress_nifi):
     # base is newer than comp
     assert utils.check_version('1.2.3', '0.2.3') == 1
     # Check RC
-    assert utils.check_version('1.0.0-rc1', '1.0.0') == -1
+    assert utils.check_version('1.0.0-rc1', '1.0.0') == 0
     # Check that snapshots are disregarded
     assert utils.check_version('1.11.0', '1.13.0-SNAPSHOT') == -1
     assert utils.check_version('1.11.0', "1.11.0-SNAPSHOT") == 0
@@ -158,3 +158,9 @@ def test_check_version(regress_nifi):
     assert utils.check_version(
         system.get_nifi_version_info().ni_fi_version
     ) == 0
+    # Check 2.0.0-M4
+    assert utils.check_version('2.0.0-M4', '2', service='nifi') == 0
+    assert utils.check_version('2', '2.0.0-M4') == 0
+    # Check 2.x vs 1.x
+    assert utils.check_version('2.0.0-M4', '1.13.0') == 1
+    assert utils.check_version('1.13.0', '2.0.0-M4') == -1

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage
 commands =
     pip install -U pip
-    coverage run -m pytest
+    coverage run -m pytest -W ignore -W ignore::urllib3.exceptions.InsecureRequestWarning
     coverage report -m
     coverage xml -o coverage-{envname}.xml
 


### PR DESCRIPTION
Updates NiPyAPI to be roughly forward compatible with NiFi-2.x line.
Note that this does not implement the full API Clients for NiFi-2.x and NiFi-Registry-2.x, it only ensures that calls made using this client generated from the 1.27.0 swagger definition appear to work correctly according to existing tests.

- Instruct pytest to not report insecure http requests to localhost for docker testing 
- Templates are deprecated in nifi-2x, remove from tests for newer versions
- Add function to check registry version using newer aboutapi() call
- Update utils.check_version to ignore any non-semver elements of a version string and use newer registry version api call if available
- Update registry client creation to handle nifi-2x structure
- Update Testing to treat NiFI-2.x as latest
- Deprecate very old nifi-1x versions from regression testing
- Fix get processor test to use a processor available in all nifi versions, GenerateFlowfile