### PR TITLE
Add support for mTLS

### DIFF
--- a/docs/devnotes.rst
+++ b/docs/devnotes.rst
@@ -17,7 +17,7 @@ Decision Points
 Testing Notes
 -------------
 
-When running tests on new code, you are advised to run 'test_default' first, then 'test_regression', then finally 'test_security'.
+When running tests on new code, you are advised to run 'test_default' first, then 'test_regression', then finally 'test_ldap' and/or 'test_mtls'.
 Because of the way errors are propagated you may have code failures which cause a teardown which then fails because of security controls, which can then obscure the original error.
 
 

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -1278,7 +1278,7 @@ def schedule_controller(controller, scheduled, refresh=False):
     raise ValueError("Scheduling request timed out")
 
 
-def get_controller(identifier, identifier_type='name', bool_response=False):
+def get_controller(identifier, identifier_type='name', bool_response=False, include_reporting_tasks=True):
     """
     Retrieve a given Controller
 
@@ -1287,6 +1287,7 @@ def get_controller(identifier, identifier_type='name', bool_response=False):
         identifier_type (str): 'id' or 'name', defaults to name
         bool_response (bool): If True, will return False if the Controller is
             not found - useful when testing for deletion completion
+        include_reporting_tasks (bool): If True, will include Reporting Tasks in the search
 
     Returns:
 
@@ -1299,7 +1300,7 @@ def get_controller(identifier, identifier_type='name', bool_response=False):
         if identifier_type == 'id':
             out = handle.get_controller_service(identifier)
         else:
-            obj = list_all_controllers(include_reporting_tasks=True)
+            obj = list_all_controllers(include_reporting_tasks=include_reporting_tasks)
             out = nipyapi.utils.filter_obj(obj, identifier, identifier_type)
     except nipyapi.nifi.rest.ApiException as e:
         if bool_response:

--- a/nipyapi/canvas.py
+++ b/nipyapi/canvas.py
@@ -1106,13 +1106,14 @@ def create_controller(parent_pg, controller, name=None):
     return out
 
 
-def list_all_controllers(pg_id='root', descendants=True):
+def list_all_controllers(pg_id='root', descendants=True, include_reporting_tasks=False):
     """
     Lists all controllers under a given Process Group, defaults to Root
         Optionally recurses all child Process Groups as well
     Args:
         pg_id (str): String of the ID of the Process Group to list from
         descendants (bool): True to recurse child PGs, False to not
+        include_reporting_tasks (bool): True to include Reporting Tasks, False to not
 
     Returns:
         None, ControllerServiceEntity, or list(ControllerServiceEntity)
@@ -1145,6 +1146,9 @@ def list_all_controllers(pg_id='root', descendants=True):
             pg_id,
             include_descendant_groups=descendants
         ).controller_services
+    if include_reporting_tasks:
+        mgmt_handle = nipyapi.nifi.FlowApi()
+        out += mgmt_handle.get_controller_services_from_controller().controller_services
     return out
 
 
@@ -1295,7 +1299,7 @@ def get_controller(identifier, identifier_type='name', bool_response=False):
         if identifier_type == 'id':
             out = handle.get_controller_service(identifier)
         else:
-            obj = list_all_controllers()
+            obj = list_all_controllers(include_reporting_tasks=True)
             out = nipyapi.utils.filter_obj(obj, identifier, identifier_type)
     except nipyapi.nifi.rest.ApiException as e:
         if bool_response:

--- a/nipyapi/config.py
+++ b/nipyapi/config.py
@@ -106,9 +106,11 @@ default_nifi_username = "nobel"
 default_nifi_password = "password"
 default_registry_username = "nobel"
 default_registry_password = "password"
+# Identity to be used for mTLS authentication
+default_mtls_identity = "CN=user1, OU=nifi"
 # Identity to be used in the Registry Client Proxy setup
 # If called for during policy setup, particularly bootstrap_policies
-default_proxy_user = "CN=localhost, OU=nifi"
+default_proxy_user = "CN=user1, OU=nifi"
 
 # Auth handling
 # If set, NiPyAPI will always include the Basic Authorization header

--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -949,7 +949,7 @@ def bootstrap_security_policies(service, user_identity=None, group_identity=None
 
 def create_ssl_context_controller_service(
         parent_pg, name, keystore_file, keystore_password, truststore_file, truststore_password, 
-        key_password=None, keystore_type=None, truststore_type=None, ssl_protocol=None):
+        key_password=None, keystore_type=None, truststore_type=None, ssl_protocol=None, ssl_service_type=None):
     """
     Creates and configures an SSL Context Service for secure client connections.
     Note that once created it can be listed and deleted using the standard canvas functions.
@@ -964,8 +964,9 @@ def create_ssl_context_controller_service(
         key_password (Optional[str]): Password for the key, defaults to keystore_password if not set
         keystore_type (Optional[str]): Type of keystore (JKS, PKCS12), defaults to JKS
         truststore_type (Optional[str]): Type of truststore (JKS, PKCS12), defaults to JKS
-        ssl_protocol (Optional[str]): SSL protocol version, defaults to SSL
-    
+        ssl_protocol (Optional[str]): SSL protocol version, defaults to TLS
+        ssl_service_type (Optional[str]): SSL service type, defaults to StandardRestrictedSSLContextService
+
     Returns:
         (ControllerServiceEntity): The configured SSL Context Service
     """
@@ -987,7 +988,7 @@ def create_ssl_context_controller_service(
                     version=0
                 ),
                 component=nipyapi.nifi.ControllerServiceDTO(
-                    type='org.apache.nifi.ssl.StandardSSLContextService',
+                    type= ssl_service_type or 'org.apache.nifi.ssl.StandardRestrictedSSLContextService',
                     name=name,
                     properties={
                         'Keystore Filename': keystore_file,
@@ -997,7 +998,7 @@ def create_ssl_context_controller_service(
                         'Truststore Filename': truststore_file,
                         'Truststore Password': truststore_password,
                         'Truststore Type': truststore_type or 'JKS',
-                        'SSL Protocol': ssl_protocol or 'SSL'
+                        'SSL Protocol': ssl_protocol or 'TLS'
                     }
                 )
             )

--- a/resources/docker/latest/docker-compose.yml
+++ b/resources/docker/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nifi:
-    image: apache/nifi:latest
+    image: apache/nifi:1.28.1
     container_name: nifi
     hostname: nifi
     ports:
@@ -9,7 +9,7 @@ services:
       - SINGLE_USER_CREDENTIALS_USERNAME=nobel
       - SINGLE_USER_CREDENTIALS_PASSWORD=supersecret1!
   registry:
-    image: apache/nifi-registry:latest
+    image: apache/nifi-registry:1.28.1
     container_name: registry
     hostname: registry
     ports:

--- a/resources/docker/secure-ldap/docker-compose.yml
+++ b/resources/docker/secure-ldap/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   secure-nifi:
-    image: apache/nifi:latest
+    image: apache/nifi:1.28.1
     container_name: secure-nifi
     hostname: secure-nifi
     ports:
@@ -25,7 +25,7 @@ services:
       - LDAP_URL=ldap://ldap.forumsys.com:389
       - NIFI_WEB_PROXY_HOST=localhost:9443,localhost:8443
   secure-registry:
-    image: apache/nifi-registry:latest
+    image: apache/nifi-registry:1.28.1
     container_name: secure-registry
     hostname: secure-registry
     ports:

--- a/resources/docker/secure-mtls/docker-compose.yml
+++ b/resources/docker/secure-mtls/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  secure-nifi:
+    image: apache/nifi:1.28.1
+    container_name: secure-nifi
+    hostname: secure-nifi
+    ports:
+      - "9443:8443"
+    volumes:
+      - ../../../nipyapi/demo/keys:/opt/certs:z
+    environment:
+      - AUTH=tls
+      - KEYSTORE_PATH=/opt/certs/localhost-ks.jks
+      - KEYSTORE_TYPE=JKS
+      - KEYSTORE_PASSWORD=localhostKeystorePassword
+      - TRUSTSTORE_PATH=/opt/certs/localhost-ts.jks
+      - TRUSTSTORE_PASSWORD=localhostTruststorePassword
+      - TRUSTSTORE_TYPE=JKS
+      - INITIAL_ADMIN_IDENTITY=CN=user1, OU=nifi
+      - NIFI_WEB_PROXY_HOST=localhost:9443,localhost:8443
+      - NIFI_WEB_HTTPS_PORT=8443
+      - NIFI_WEB_HTTPS_HOST=0.0.0.0
+      - NIFI_SECURITY_NEEDCLIENTAUTH=true
+      - NIFI_SECURITY_USER_AUTHORIZER=managed-authorizer
+      - NIFI_SECURITY_USER_LOGIN_IDENTITY_PROVIDER=
+      - NIFI_SECURITY_ALLOW_ANONYMOUS_AUTHENTICATION=false
+      - SINGLE_USER_CREDENTIALS_USERNAME=
+      - SINGLE_USER_CREDENTIALS_PASSWORD=
+    networks:
+      - nifi-net
+
+  secure-registry:
+    image: apache/nifi-registry:1.28.1
+    container_name: secure-registry
+    hostname: secure-registry
+    ports:
+      - "18443:18443"
+    volumes:
+      - ../../../nipyapi/demo/keys:/opt/certs:z
+    environment:
+      - AUTH=tls
+      - KEYSTORE_PATH=/opt/certs/localhost-ks.jks
+      - KEYSTORE_TYPE=JKS
+      - KEYSTORE_PASSWORD=localhostKeystorePassword
+      - TRUSTSTORE_PATH=/opt/certs/localhost-ts.jks
+      - TRUSTSTORE_PASSWORD=localhostTruststorePassword
+      - TRUSTSTORE_TYPE=JKS
+      - INITIAL_ADMIN_IDENTITY=CN=user1, OU=nifi
+      - NIFI_REGISTRY_WEB_HTTPS_PORT=18443
+      - NIFI_REGISTRY_WEB_HTTPS_HOST=0.0.0.0
+      - NIFI_REGISTRY_SECURITY_NEEDCLIENTAUTH=true
+      - NIFI_REGISTRY_SECURITY_USER_AUTHORIZER=managed-authorizer
+      - NIFI_REGISTRY_SECURITY_IDENTITY_PROVIDER=
+      - NIFI_REGISTRY_SECURITY_ALLOW_ANONYMOUS_AUTHENTICATION=false
+    networks:
+      - nifi-net
+
+networks:
+  nifi-net:
+    driver: bridge

--- a/resources/docker/tox-full/docker-compose.yml
+++ b/resources/docker/tox-full/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - SINGLE_USER_CREDENTIALS_PASSWORD=supersecret1!
       - NIFI_WEB_HTTPS_PORT=10127
   nifi:
-    image: apache/nifi:2.2.0
+    image: apache/nifi:1.28.1
     container_name: nifi
     hostname: nifi
     ports:
@@ -41,7 +41,7 @@ services:
     environment:
       - NIFI_REGISTRY_WEB_HTTP_PORT=18127
   registry:
-    image: apache/nifi-registry:2.2.0
+    image: apache/nifi-registry:1.28.1
     container_name: registry
     hostname: registry
     ports:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py39, py312, flake8, lint
+envlist = py39, py310, py312, flake8, lint
+ignore_basepython_conflict = true  # resolves issue with pyenv on Windows testing
 
 [testenv]
 deps =


### PR DESCRIPTION
- Added Python3.10 as it historically had urllib3 changes that caused issues. 
- Renamed the 'secure' test mode to 'secure-ldap' distinguish it from 'secure-mtls'. 
- Added 'secure-mtls' test mode with docker configuration and pytest setup. 
- Added including 'reporting tasks' to some controller functions as the management controllers fall into that group and the SSL Context controller required for secure registry falls into that category. 
- Changed the default_proxy_user in config.py to user1 instead of localhost to match the certs.
- Added optional 'purpose' overide to security/set_service_ssl_context to handle certificates needing to be either CLIENT or SERVER auth. Should fix issue #370. 
- bootstrap_security_policies changed to read system_diagnostics and policies by default. 
- Added default registry policy setup for the nifi proxy user. 
- Added security.py function to create_ssl_context_controller_service which is required to create the registry client in an mTLS environment. 
- Updated utils/set_endpoint to handle correctly setting the SSL Context for mTLS when login is not requested, and not just LDAPS. This allows easy mTLS usage as shown in conftest. 
- Updated versioning/create_registry_client to accept an SSL Context Service to setup the secure registry connection under mTLS.
- Locked latest for testing to be 1.28.1 for this branch of NiPyAPI as testing against 2.x is not a full test suite. 
- pytest now has an additional mode secure_mtls, which clones the secure_ldap setup. You can only use either mtls or ldap concurrently as they share network names in the certificates.

Tested all test modes using Docker Desktop on Windows10