### PR TITLE
fix: add ParameterProvider and FlowAnalysisRule to reference_type allowed values

### DIFF
--- a/nipyapi/nifi/models/controller_service_referencing_component_dto.py
+++ b/nipyapi/nifi/models/controller_service_referencing_component_dto.py
@@ -278,7 +278,7 @@ class ControllerServiceReferencingComponentDTO(object):
         :param reference_type: The reference_type of this ControllerServiceReferencingComponentDTO.
         :type: str
         """
-        allowed_values = ["Processor", "ControllerService", "ReportingTask", "FlowRegistryClient", ]
+        allowed_values = ["Processor", "ControllerService", "ReportingTask", "FlowRegistryClient", "ParameterProvider", "FlowAnalysisRule", ]
         if reference_type not in allowed_values:
             raise ValueError(
                 "Invalid value for `reference_type` ({0}), must be one of {1}"


### PR DESCRIPTION
## Summary

- Adds `ParameterProvider` and `FlowAnalysisRule` to the `allowed_values` list in `ControllerServiceReferencingComponentDTO.reference_type` setter
- These component types were added in NiFi 2.x and can reference ControllerServices, but nipyapi's model validation rejects them

Fixes #406

## Details

NiFi's `DtoFactory.java` (lines 1928-1983) sets `referenceType` based on the component type:
- `Processor` ✅ already in allowed_values
- `ControllerService` ✅ already in allowed_values
- `ReportingTask` ✅ already in allowed_values
- `FlowRegistryClient` ✅ already in allowed_values
- `ParameterProvider` ❌ **added in this PR**
- `FlowAnalysisRule` ❌ **added in this PR**

Note: NiFi's own OpenAPI/Swagger spec enum for this field is also incomplete (only lists Processor, ControllerService, ReportingTask, FlowRegistryClient), so auto-generation from swagger alone won't catch this.